### PR TITLE
Initial support for nostr wallet connect

### DIFF
--- a/app/(main)/zap/[address].tsx
+++ b/app/(main)/zap/[address].tsx
@@ -1,0 +1,42 @@
+import { webln } from 'alby-js-sdk'
+import { useSearchParams } from 'expo-router'
+import { useEffect } from 'react'
+import { Stack } from 'expo-router'
+import { StyleSheet, Text, View } from 'react-native'
+
+export default function Page() {
+  const { address }: any = useSearchParams()
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>zap {address}</Text>
+      <Stack.Screen options={{ title: 'Send zap to ' + address }} />
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    height: '100%',
+    width: '100%',
+    backgroundColor: 'transparent',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  title: {
+    color: '#fff',
+    fontFamily: 'Protomolecule',
+    fontSize: 60,
+    textShadowColor: 'cyan',
+    textShadowRadius: 14,
+  },
+  subtitle: {
+    color: '#fff',
+    fontFamily: 'Protomolecule',
+    fontSize: 20,
+    textShadowColor: 'cyan',
+    textShadowRadius: 14,
+    marginTop: 20,
+  },
+})

--- a/app/(main)/zap/_layout.tsx
+++ b/app/(main)/zap/_layout.tsx
@@ -1,0 +1,17 @@
+import { Stack } from 'expo-router/stack'
+import { color, typography } from 'views/theme'
+
+export default function Layout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerStyle: { backgroundColor: color.palette.darkGray },
+        headerShadowVisible: false,
+        headerTintColor: color.palette.white,
+        headerTitleStyle: {
+          fontFamily: typography.secondary,
+        },
+      }}
+    />
+  )
+}

--- a/app/alby.tsx
+++ b/app/alby.tsx
@@ -52,7 +52,10 @@ export default function Alby() {
       await nwc.enable()
 
       const response: any = await nwc.sendPayment(invoice)
-      setMessage(`payment successful, the preimage is ${response.preimage}`)
+      if (response?.preimage) {
+        nwc.close()
+        setMessage(`payment successful, the preimage is ${response.preimage}`)
+      }
     } else {
       setMessage('invoice invalid')
     }


### PR DESCRIPTION
**Add:**

- Initial screen for zap: `(main)/zap/[address]`
- `getInvoiceFromAddress` function to generate invoice with user input `lightning address`
- `sendZap` function to send zap to specific invoice

**Change:**

- `initAlby` function, run this function will trigger open `Nostr Wallet Connect` verification page as new tab and return `NostrWalletConnectUrl` for future use

**Flow:**

- User visit `/alby` page, app auto trigger connect to Alby, and open `Nostr Wallet Connect` verification page as new tab
- User enter their lightning address and click `Zap` button, app auto generate invoice (fixed 21 sats), then push this invoice to `sendPayment` function
- If send payment success, send message to user