### PR TITLE
Minor updates UI

### DIFF
--- a/app/navigators/TabBar.tsx
+++ b/app/navigators/TabBar.tsx
@@ -48,8 +48,8 @@ export const TabBar = ({ state, descriptors, navigation }: BottomTabBarProps) =>
                 entering={FadeIn.delay(500 + 50 * index).duration(300)}
                 style={$tab}
               >
-                <TouchableOpacity onPress={onPress} activeOpacity={0.8}>
-                  {IconComponent && <IconComponent focused={isFocused} />}
+                <TouchableOpacity onPress={onPress} activeOpacity={0.8} style={$button}>
+                  {IconComponent && <IconComponent focused={isFocused} style={$button} />}
                 </TouchableOpacity>
               </Animated.View>
             )
@@ -81,4 +81,12 @@ const $tab: ViewStyle = {
   flex: 1,
   justifyContent: "center",
   alignItems: "center",
+  height: 65,
+}
+
+const $button: ViewStyle = {
+  height: 65,
+  width: '100%',
+  alignItems: 'center',
+  justifyContent: 'center'
 }

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -75,22 +75,22 @@ export const ProfileScreen: FC<ProfileScreenProps> = observer(function ProfileSc
             <View style={$sectionHeadingButton}>
               <Text text="Account" preset="bold" style={$sectionHeading} />
               <Pressable onPress={() => navigation.navigate("EditProfile")}>
-                <EditIcon width={20} height={20} color={colors.palette.cyan500} />
+                <EditIcon width={24} height={24} color={colors.palette.cyan500} />
               </Pressable>
             </View>
             <View style={$sectionData}>
-              <View style={$sectionDataItem}>
+              <Pressable onPress={() => navigation.navigate("EditProfile")} style={$sectionDataItem}>
                 <Text text={profile?.username || "No username"} />
                 <Text text="Username" size="xs" style={$sectionDataItemSubtitle} />
-              </View>
-              <View style={$sectionDataItem}>
+              </Pressable>
+              <Pressable onPress={() => navigation.navigate("EditProfile")} style={$sectionDataItem}>
                 <Text text={profile?.nip05 || "No NIP-05"} />
                 <Text text="NIP-05" size="xs" style={$sectionDataItemSubtitle} />
-              </View>
-              <View style={$sectionDataItem}>
+              </Pressable>
+              <Pressable onPress={() => navigation.navigate("EditProfile")} style={$sectionDataItem}>
                 <Text text="Bio" size="xs" style={$sectionDataItemSubtitle} />
                 <Text text={profile?.about || profile?.bio || "No bio"} />
-              </View>
+              </Pressable>
             </View>
           </View>
           <View>


### PR DESCRIPTION
**Changes**:

- Increase Edit Profile icon
- In Profile screen, user can click to account's information (username/nip05/bio) to open Edit Profile screen too
- Make tabbar's icon press zone larger

Old:
<img width="409" alt="Screenshot 2023-06-12 at 17 04 15" src="https://github.com/ArcadeLabsInc/arcade/assets/123083837/c6e52513-68e4-4e96-854c-326d1e2cc39d">

New:
<img width="409" alt="image" src="https://github.com/ArcadeLabsInc/arcade/assets/123083837/fe8b6908-ca99-47fd-a4ef-98e50659846b">
