### PR TITLE
feat: blurred popup menu handler

### DIFF
--- a/app/components/BlurredPopup/BlurredContext.tsx
+++ b/app/components/BlurredPopup/BlurredContext.tsx
@@ -1,8 +1,14 @@
 import React from "react"
-import { MeasuredDimensions } from "react-native-reanimated"
+import type { MeasuredDimensions } from "react-native-reanimated"
 
+/**
+ * Specifies the alignment options for the popup menu.
+ */
 type PopupAlignment = "top-left" | "top-right" | "bottom-left" | "bottom-right"
 
+/**
+ * Defines the shape of a popup option.
+ */
 type PopupOptionType = {
   label: string
   onPress?: () => void
@@ -10,17 +16,29 @@ type PopupOptionType = {
   trailing?: React.ReactNode
 }
 
+/**
+ * Defines the shape of the context object for the blurred popup menu.
+ */
 type BlurredContextType = {
-  showPopup: (_: {
+  /**
+   * Shows the popup menu with the specified parameters.
+   * @param layout - The measured dimensions of the component triggering the popup.
+   * @param node - The component triggering the popup.
+   * @param options - The options for the popup menu.
+   */
+  showPopup: (params: {
     layout: MeasuredDimensions
     node: React.ReactNode
     options: PopupOptionType[]
   }) => void
 }
 
+/**
+ * The context object used to provide the blurred popup menu functionality.
+ */
 const BlurredPopupContext = React.createContext<BlurredContextType>({
   showPopup: () => {
-    //
+    // Default showPopup function does nothing
   },
 })
 

--- a/app/components/BlurredPopup/BlurredContext.tsx
+++ b/app/components/BlurredPopup/BlurredContext.tsx
@@ -1,0 +1,27 @@
+import React from "react"
+import { MeasuredDimensions } from "react-native-reanimated"
+
+type PopupAlignment = "top-left" | "top-right" | "bottom-left" | "bottom-right"
+
+type PopupOptionType = {
+  label: string
+  onPress?: () => void
+  leading?: React.ReactNode
+  trailing?: React.ReactNode
+}
+
+type BlurredContextType = {
+  showPopup: (_: {
+    layout: MeasuredDimensions
+    node: React.ReactNode
+    options: PopupOptionType[]
+  }) => void
+}
+
+const BlurredPopupContext = React.createContext<BlurredContextType>({
+  showPopup: () => {
+    //
+  },
+})
+
+export { PopupAlignment, PopupOptionType, BlurredContextType, BlurredPopupContext }

--- a/app/components/BlurredPopup/BlurredPopupProvider.tsx
+++ b/app/components/BlurredPopup/BlurredPopupProvider.tsx
@@ -1,0 +1,224 @@
+import {
+  Canvas,
+  makeImageFromView,
+  Image,
+  useValue,
+  useComputedValue,
+  rect,
+  Blur,
+  SkImage,
+  runTiming,
+  useValueEffect,
+} from "@shopify/react-native-skia"
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { View, StyleSheet, TouchableOpacity, ViewProps, ViewStyle } from "react-native"
+
+import Animated, {
+  FadeIn,
+  FadeOut,
+  Layout,
+  MeasuredDimensions,
+  useAnimatedProps,
+} from "react-native-reanimated"
+import { Text } from "../Text"
+import { BlurredPopupContext, PopupAlignment, PopupOptionType } from "./BlurredContext"
+
+type BlurredPopupProviderProps = {
+  children?: React.ReactNode
+}
+
+const BlurredPopupProvider: React.FC<BlurredPopupProviderProps> = ({ children }) => {
+  const [params, setParams] = useState<{
+    image: SkImage
+    node: React.ReactNode
+    layout: MeasuredDimensions
+    options?: PopupOptionType[]
+  } | null>(null)
+
+  const image = useMemo(() => {
+    if (!params) return null
+    return params.image
+  }, [params])
+
+  const options = useMemo(() => {
+    if (!params) return []
+    return params.options
+  }, [params])
+
+  const mainView = useRef(null)
+
+  const showPopup = useCallback(
+    async ({
+      node,
+      layout,
+      options,
+    }: {
+      node: React.ReactNode
+      layout: MeasuredDimensions
+      options: PopupOptionType[]
+    }) => {
+      const skImage = await makeImageFromView(mainView)
+      setParams({ image: skImage, node, layout, options })
+    },
+    [],
+  )
+
+  const canvasSize = useValue({ width: 0, height: 0 })
+
+  const sBlurValue = useValue(0)
+
+  const close = useCallback(() => {
+    runTiming(sBlurValue, 0, {
+      duration: 200,
+    })
+  }, [])
+
+  useEffect(() => {
+    if (image) {
+      runTiming(sBlurValue, 10, {
+        duration: 200,
+      })
+    }
+  }, [image])
+
+  useValueEffect(sBlurValue, (value) => {
+    if (value === 0) {
+      setParams(null)
+    }
+  })
+
+  const imageRect = useComputedValue(() => {
+    return rect(0, 0, canvasSize.current.width, canvasSize.current.height)
+  }, [canvasSize])
+
+  const nodeStyle = useMemo(() => {
+    if (!params) return {} as any
+    return {
+      position: "absolute",
+      top: params.layout.pageY,
+      left: params.layout.pageX,
+      width: params.layout.width,
+      height: params.layout.height,
+      zIndex: -10,
+    }
+  }, [params])
+
+  const popupItems = options.length
+  const popupItemsHeight = 50
+  const popupHeight = popupItemsHeight * popupItems
+
+  const popupStyle = useMemo(() => {
+    if (!params) return {} as ViewStyle
+    const { pageX, pageY, width, height } = params.layout
+
+    const yAlignment = canvasSize.current.height - pageY - popupHeight < 100 ? "top" : "bottom"
+    const xAlignment = canvasSize.current.width - pageX > 200 ? "left" : "left"
+    const alignment: PopupAlignment = `${yAlignment}-${xAlignment}` as PopupAlignment
+
+    const x = alignment.includes("right") ? pageX + width : pageX
+    const y = alignment.includes("bottom") ? pageY + height : pageY - popupHeight
+
+    return {
+      position: "absolute",
+      top: y,
+      left: x,
+      height: popupHeight,
+    } as ViewStyle
+  }, [params, popupHeight])
+
+  const hasParams = params != null
+  const pointerEventsProps = useAnimatedProps(() => {
+    return {
+      pointerEvents: hasParams ? "auto" : "none",
+    } as Partial<ViewProps>
+  }, [hasParams])
+
+  const canvasStyle = useMemo(() => {
+    return {
+      ...StyleSheet.absoluteFillObject,
+      zIndex: image ? 100 : -10,
+      backgroundColor: "transparent",
+    }
+  }, [image])
+
+  return (
+    <>
+      <BlurredPopupContext.Provider value={{ showPopup }}>
+        <Animated.View animatedProps={pointerEventsProps} style={styles.mainPopupContainerView}>
+          {params?.image != null && popupItems != null && (
+            <Animated.View
+              layout={Layout}
+              entering={FadeIn.delay(100)}
+              exiting={FadeOut}
+              style={[popupStyle, styles.popup]}
+            >
+              {options.map(({ leading, trailing, label, onPress }, index) => {
+                return (
+                  <TouchableOpacity
+                    onPress={() => {
+                      close()
+                      onPress()
+                    }}
+                    activeOpacity={0.9}
+                    key={index}
+                    style={{
+                      height: popupItemsHeight,
+                      backgroundColor: "rgba(255,255,255,0.75)",
+                      alignItems: "center",
+                      paddingHorizontal: 10,
+                      flexDirection: "row",
+                    }}
+                  >
+                    {leading}
+                    <Text style={{ color: "black", marginRight: 10, marginLeft: 5 }}>{label}</Text>
+                    {trailing}
+                  </TouchableOpacity>
+                )
+              })}
+            </Animated.View>
+          )}
+          <View
+            style={{
+              ...StyleSheet.absoluteFillObject,
+              zIndex: -5,
+            }}
+            onTouchEnd={close}
+          />
+          <Animated.View style={nodeStyle}>{params?.node}</Animated.View>
+        </Animated.View>
+        <Canvas
+          onSize={canvasSize}
+          style={canvasStyle}
+          onTouchEnd={() => {
+            close()
+          }}
+        >
+          {image && (
+            <Image rect={imageRect} image={image}>
+              <Blur blur={sBlurValue} />
+            </Image>
+          )}
+        </Canvas>
+        <View ref={mainView} style={styles.container}>
+          {children}
+        </View>
+      </BlurredPopupContext.Provider>
+    </>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  mainPopupContainerView: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 500,
+  },
+  popup: {
+    borderRadius: 5,
+    overflow: "hidden",
+  },
+})
+
+export { BlurredPopupProvider }

--- a/app/components/BlurredPopup/BlurredPopupProvider.tsx
+++ b/app/components/BlurredPopup/BlurredPopupProvider.tsx
@@ -120,6 +120,10 @@ const BlurredPopupProvider: React.FC<BlurredPopupProviderProps> = ({
   // Just a Skia Value (The "s" is simply a convention)
   const sBlurValue = useValue(0)
 
+  const sLightBlurValue = useComputedValue(() => {
+    return sBlurValue.current / 3
+  }, [sBlurValue])
+
   const dismissBlurredPopup = useCallback(() => {
     runTiming(sBlurValue, 0, {
       duration: 200,
@@ -271,9 +275,14 @@ const BlurredPopupProvider: React.FC<BlurredPopupProviderProps> = ({
         </Animated.View>
         <Canvas onSize={canvasSize} style={canvasStyle} onTouchEnd={close}>
           {image && (
-            <Image rect={imageRect} image={image}>
-              <Blur blur={sBlurValue} />
-            </Image>
+            <>
+              <Image rect={imageRect} image={image}>
+                <Blur blur={sLightBlurValue} />
+              </Image>
+              <Image rect={imageRect} image={image}>
+                <Blur blur={sBlurValue} />
+              </Image>
+            </>
           )}
         </Canvas>
         {/* The main content of the application */}

--- a/app/components/BlurredPopup/TouchablePopupHandler.tsx
+++ b/app/components/BlurredPopup/TouchablePopupHandler.tsx
@@ -10,13 +10,34 @@ import Animated, {
 import { BlurredPopupContext, PopupOptionType } from "./BlurredContext"
 
 type TouchablePopupHandlerProps = {
+  /**
+   * The content to be wrapped by the `TouchablePopupHandler` component.
+   */
   children?: React.ReactNode
+  /**
+   * An alternative content to be displayed in the popup instead of the wrapped content.
+   */
   highlightedChildren?: React.ReactNode
+  /**
+   * The style to be applied to the wrapped view.
+   */
   style?: StyleProp<ViewStyle>
+  /**
+   * A callback function to be called when the wrapped view is pressed.
+   */
   onPress?: () => void
+  /**
+   * An array of options for the popup menu.
+   */
   options: PopupOptionType[]
 }
 
+/**
+ * TouchablePopupHandler is a component used to wrap the node that will trigger a popup.
+ * It provides a LongPress gesture that, when triggered, measures the dimensions of the wrapped node
+ * and shows the popup using the BlurredPopupContext.
+ * It also supports a single tap gesture that can trigger an optional onPress callback.
+ */
 const TouchablePopupHandler: React.FC<TouchablePopupHandlerProps> = ({
   children,
   style,
@@ -24,9 +45,15 @@ const TouchablePopupHandler: React.FC<TouchablePopupHandlerProps> = ({
   highlightedChildren,
   options,
 }) => {
+  // We use an Animated Ref to measure the node dimensions on the UI Thread
   const viewRef = useAnimatedRef<Animated.View>()
   const { showPopup } = useContext(BlurredPopupContext)
 
+  /**
+   * Wrapped function that calls the showPopup function with the measured dimensions and other options.
+   * This function is passed to runOnJS to ensure it's executed on the JS thread.
+   * @param layout - The measured dimensions of the wrapped node.
+   */
   const wrappedJsShowPopup = useCallback(
     (layout: MeasuredDimensions) => {
       showPopup({ layout, node: highlightedChildren ?? children, options })
@@ -34,18 +61,26 @@ const TouchablePopupHandler: React.FC<TouchablePopupHandlerProps> = ({
     [showPopup, options],
   )
 
+  // Create a LongPress gesture that triggers the wrappedJsShowPopup function when started.
   const longPressGesture = Gesture.LongPress()
     .minDuration(1000)
     .onStart(() => {
+      // Measure the node dimensions on the UI Thread, thanks to the useAnimatedRef hook
+      // The measure function is a Reanimated function that returns a MeasuredDimensions object
       const dimensions = measure(viewRef) // Sync measure
+
+      // Since the showPopup function is not a Reanimated function, we need to wrap it with runOnJS
       runOnJS(wrappedJsShowPopup)(dimensions)
     })
 
-  const tapGesture = Gesture.Tap().onTouchesUp(() => {
+  // Create a single tap gesture that triggers the onPress function when the user taps on the node.
+  const singleTapGesture = Gesture.Tap().onTouchesUp(() => {
+    // If the user taps on the node, we call the onPress function
     if (onPress) runOnJS(onPress)()
   })
 
-  const gesture = Gesture.Exclusive(longPressGesture, tapGesture)
+  // To avoid conflicts between the two gestures, we use the Exclusive Gesture.
+  const gesture = Gesture.Exclusive(longPressGesture, singleTapGesture)
 
   return (
     <GestureDetector gesture={gesture}>

--- a/app/components/BlurredPopup/TouchablePopupHandler.tsx
+++ b/app/components/BlurredPopup/TouchablePopupHandler.tsx
@@ -68,7 +68,7 @@ const TouchablePopupHandler: React.FC<TouchablePopupHandlerProps> = ({
 
   // Create a LongPress gesture that triggers the wrappedJsShowPopup function when started.
   const longPressGesture = Gesture.LongPress()
-    .minDuration(1000)
+    .minDuration(500)
     .onStart(() => {
       // Measure the node dimensions on the UI Thread, thanks to the useAnimatedRef hook
       // The measure function is a Reanimated function that returns a MeasuredDimensions object

--- a/app/components/BlurredPopup/TouchablePopupHandler.tsx
+++ b/app/components/BlurredPopup/TouchablePopupHandler.tsx
@@ -1,0 +1,59 @@
+import React, { useCallback, useContext } from "react"
+import { StyleProp, ViewStyle } from "react-native"
+import { Gesture, GestureDetector } from "react-native-gesture-handler"
+import Animated, {
+  MeasuredDimensions,
+  measure,
+  runOnJS,
+  useAnimatedRef,
+} from "react-native-reanimated"
+import { BlurredPopupContext, PopupOptionType } from "./BlurredContext"
+
+type TouchablePopupHandlerProps = {
+  children?: React.ReactNode
+  highlightedChildren?: React.ReactNode
+  style?: StyleProp<ViewStyle>
+  onPress?: () => void
+  options: PopupOptionType[]
+}
+
+const TouchablePopupHandler: React.FC<TouchablePopupHandlerProps> = ({
+  children,
+  style,
+  onPress,
+  highlightedChildren,
+  options,
+}) => {
+  const viewRef = useAnimatedRef<Animated.View>()
+  const { showPopup } = useContext(BlurredPopupContext)
+
+  const wrappedJsShowPopup = useCallback(
+    (layout: MeasuredDimensions) => {
+      showPopup({ layout, node: highlightedChildren ?? children, options })
+    },
+    [showPopup, options],
+  )
+
+  const longPressGesture = Gesture.LongPress()
+    .minDuration(1000)
+    .onStart(() => {
+      const dimensions = measure(viewRef) // Sync measure
+      runOnJS(wrappedJsShowPopup)(dimensions)
+    })
+
+  const tapGesture = Gesture.Tap().onTouchesUp(() => {
+    if (onPress) runOnJS(onPress)()
+  })
+
+  const gesture = Gesture.Exclusive(longPressGesture, tapGesture)
+
+  return (
+    <GestureDetector gesture={gesture}>
+      <Animated.View ref={viewRef} style={style}>
+        {children}
+      </Animated.View>
+    </GestureDetector>
+  )
+}
+
+export { TouchablePopupHandler }

--- a/app/components/BlurredPopup/TouchablePopupHandler.tsx
+++ b/app/components/BlurredPopup/TouchablePopupHandler.tsx
@@ -8,6 +8,7 @@ import Animated, {
   useAnimatedRef,
 } from "react-native-reanimated"
 import { BlurredPopupContext, PopupOptionType } from "./BlurredContext"
+import HapticFeedback from "react-native-haptic-feedback"
 
 type TouchablePopupHandlerProps = {
   /**
@@ -61,6 +62,10 @@ const TouchablePopupHandler: React.FC<TouchablePopupHandlerProps> = ({
     [showPopup, options],
   )
 
+  const runLightFeedback = useCallback(() => {
+    HapticFeedback.trigger("impactLight", { enableVibrateFallback: true })
+  }, [])
+
   // Create a LongPress gesture that triggers the wrappedJsShowPopup function when started.
   const longPressGesture = Gesture.LongPress()
     .minDuration(1000)
@@ -71,6 +76,8 @@ const TouchablePopupHandler: React.FC<TouchablePopupHandlerProps> = ({
 
       // Since the showPopup function is not a Reanimated function, we need to wrap it with runOnJS
       runOnJS(wrappedJsShowPopup)(dimensions)
+      // run smooth feedback on long press
+      runOnJS(runLightFeedback)()
     })
 
   // Create a single tap gesture that triggers the onPress function when the user taps on the node.

--- a/app/components/BlurredPopup/index.tsx
+++ b/app/components/BlurredPopup/index.tsx
@@ -1,0 +1,4 @@
+import { BlurredPopupProvider } from "./BlurredPopupProvider"
+import { TouchablePopupHandler } from "./TouchablePopupHandler"
+
+export { BlurredPopupProvider, TouchablePopupHandler }

--- a/app/navigators/AppNavigator.tsx
+++ b/app/navigators/AppNavigator.tsx
@@ -9,6 +9,7 @@ import { navigationRef, useBackButtonHandler } from "./navigationUtilities"
 import { TabNavigator } from "./TabNavigator"
 import { AuthNavigator } from "./AuthNavigator"
 import { useStores } from "app/models"
+import { BlurredPopupProvider } from "app/components/BlurredPopup"
 
 export type AppStackParamList = {
   Auth: undefined
@@ -102,7 +103,9 @@ export const AppNavigator = observer(function AppNavigator(props: NavigationProp
       theme={colorScheme === "dark" ? DarkTheme : DefaultTheme}
       {...props}
     >
-      <AppStack />
+      <BlurredPopupProvider>
+        <AppStack />
+      </BlurredPopupProvider>
     </NavigationContainer>
   )
 })

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -19,7 +19,7 @@ import { useFocusEffect, useNavigation } from "@react-navigation/native"
 import { nip19 } from "nostr-tools"
 import { useStores } from "app/models"
 import { shortenKey } from "app/utils/shortenKey"
-import { EditIcon } from "lucide-react-native"
+import { AxeIcon, EditIcon } from "lucide-react-native"
 import { NostrPool } from "app/arclib/src"
 import { ProfileManager } from "app/arclib/src/profile"
 import { TouchablePopupHandler } from "app/components/BlurredPopup"
@@ -96,40 +96,25 @@ export const ProfileScreen: FC<ProfileScreenProps> = observer(function ProfileSc
               <TouchablePopupHandler
                 options={[
                   {
-                    label: "Backup",
-                    onPress: () => navigation.navigate("Backup"),
+                    label: "Edit Profile",
+                    onPress: () => navigation.navigate("EditProfile"),
                     trailing: (
-                      <EditIcon
-                        width={20}
-                        height={20}
-                        color={colors.palette.almostBlack}
-                        style={{ marginLeft: 5 }}
-                      />
+                      <EditIcon width={20} height={20} color={colors.palette.almostBlack} />
                     ),
                   },
                   {
-                    label: "Privacy",
-                    onPress: () => navigation.navigate("PrivacySetting"),
-                    trailing: (
-                      <EditIcon
-                        width={20}
-                        height={20}
-                        color={colors.palette.almostBlack}
-                        style={{ marginLeft: 5 }}
-                      />
-                    ),
+                    label: "A Long Long Long String",
+                    trailing: <AxeIcon width={20} height={20} color={colors.palette.almostBlack} />,
                   },
                 ]}
                 onPress={() => {
-                  console.log("onPress")
+                  navigation.navigate("EditProfile")
                 }}
                 highlightedChildren={
                   <EditIcon width={24} height={24} color={colors.palette.white} />
                 }
               >
-                <Pressable onPress={() => navigation.navigate("EditProfile")}>
-                  <EditIcon width={24} height={24} color={colors.palette.cyan500} />
-                </Pressable>
+                <EditIcon width={24} height={24} color={colors.palette.cyan500} />
               </TouchablePopupHandler>
             </View>
             <View style={$sectionData}>
@@ -199,24 +184,14 @@ export const ProfileScreen: FC<ProfileScreenProps> = observer(function ProfileSc
                     label: "Backup",
                     onPress: () => navigation.navigate("Backup"),
                     trailing: (
-                      <EditIcon
-                        width={20}
-                        height={20}
-                        color={colors.palette.almostBlack}
-                        style={{ marginLeft: 5 }}
-                      />
+                      <EditIcon width={20} height={20} color={colors.palette.almostBlack} />
                     ),
                   },
                   {
                     label: "Privacy",
                     onPress: () => navigation.navigate("PrivacySetting"),
                     trailing: (
-                      <EditIcon
-                        width={20}
-                        height={20}
-                        color={colors.palette.almostBlack}
-                        style={{ marginLeft: 5 }}
-                      />
+                      <EditIcon width={20} height={20} color={colors.palette.almostBlack} />
                     ),
                   },
                 ]}
@@ -243,16 +218,6 @@ export const ProfileScreen: FC<ProfileScreenProps> = observer(function ProfileSc
                   style={$sectionButton}
                 />
               </TouchablePopupHandler>
-              {/* <ListItem
-                text="Demos"
-                leftIcon="TestTube2"
-                bottomSeparator
-                leftIconColor={colors.palette.cyan500}
-                style={$sectionButton}
-                onPress={() => {
-                  navigation.navigate("Demos")
-                }}
-              /> */}
             </View>
           </View>
           <View>

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -22,6 +22,7 @@ import { shortenKey } from "app/utils/shortenKey"
 import { EditIcon } from "lucide-react-native"
 import { NostrPool } from "app/arclib/src"
 import { ProfileManager } from "app/arclib/src/profile"
+import { TouchablePopupHandler } from "app/components/BlurredPopup"
 
 interface ProfileScreenProps extends NativeStackScreenProps<AppStackScreenProps<"Profile">> {}
 
@@ -80,6 +81,7 @@ export const ProfileScreen: FC<ProfileScreenProps> = observer(function ProfileSc
             text={profile?.display_name || profile?.name || "No name"}
             style={$userName}
           />
+
           <TouchableOpacity
             onPress={async () => await Clipboard.setStringAsync(nip19.npubEncode(userStore.pubkey))}
           >
@@ -90,9 +92,45 @@ export const ProfileScreen: FC<ProfileScreenProps> = observer(function ProfileSc
           <View>
             <View style={$sectionHeadingButton}>
               <Text text="Account" preset="bold" style={$sectionHeading} />
-              <Pressable onPress={() => navigation.navigate("EditProfile")}>
-                <EditIcon width={24} height={24} color={colors.palette.cyan500} />
-              </Pressable>
+
+              <TouchablePopupHandler
+                options={[
+                  {
+                    label: "Backup",
+                    onPress: () => navigation.navigate("Backup"),
+                    trailing: (
+                      <EditIcon
+                        width={20}
+                        height={20}
+                        color={colors.palette.almostBlack}
+                        style={{ marginLeft: 5 }}
+                      />
+                    ),
+                  },
+                  {
+                    label: "Privacy",
+                    onPress: () => navigation.navigate("PrivacySetting"),
+                    trailing: (
+                      <EditIcon
+                        width={20}
+                        height={20}
+                        color={colors.palette.almostBlack}
+                        style={{ marginLeft: 5 }}
+                      />
+                    ),
+                  },
+                ]}
+                onPress={() => {
+                  console.log("onPress")
+                }}
+                highlightedChildren={
+                  <EditIcon width={24} height={24} color={colors.palette.white} />
+                }
+              >
+                <Pressable onPress={() => navigation.navigate("EditProfile")}>
+                  <EditIcon width={24} height={24} color={colors.palette.cyan500} />
+                </Pressable>
+              </TouchablePopupHandler>
             </View>
             <View style={$sectionData}>
               <Pressable
@@ -129,14 +167,7 @@ export const ProfileScreen: FC<ProfileScreenProps> = observer(function ProfileSc
                 style={$sectionButton}
                 onPress={() => navigation.navigate("RelayManager")}
               />
-              <ListItem
-                text="Backup"
-                leftIcon="Shield"
-                leftIconColor={colors.palette.cyan500}
-                bottomSeparator={true}
-                style={$sectionButton}
-                onPress={() => navigation.navigate("Backup")}
-              />
+
               <ListItem
                 text="Notifications"
                 leftIcon="Bell"
@@ -154,6 +185,64 @@ export const ProfileScreen: FC<ProfileScreenProps> = observer(function ProfileSc
                 style={$sectionButton}
                 onPress={() => navigation.navigate("PrivacySetting")}
               />
+              <ListItem
+                text="Backup"
+                leftIcon="Shield"
+                leftIconColor={colors.palette.cyan500}
+                onPress={() => navigation.navigate("Backup")}
+                bottomSeparator={true}
+                style={$sectionButton}
+              />
+              <TouchablePopupHandler
+                options={[
+                  {
+                    label: "Backup",
+                    onPress: () => navigation.navigate("Backup"),
+                    trailing: (
+                      <EditIcon
+                        width={20}
+                        height={20}
+                        color={colors.palette.almostBlack}
+                        style={{ marginLeft: 5 }}
+                      />
+                    ),
+                  },
+                  {
+                    label: "Privacy",
+                    onPress: () => navigation.navigate("PrivacySetting"),
+                    trailing: (
+                      <EditIcon
+                        width={20}
+                        height={20}
+                        color={colors.palette.almostBlack}
+                        style={{ marginLeft: 5 }}
+                      />
+                    ),
+                  },
+                ]}
+                onPress={() => {
+                  console.log("onPress")
+                }}
+                highlightedChildren={
+                  <ListItem
+                    text="Demo"
+                    leftIcon="DumbbellIcon"
+                    leftIconColor={colors.palette.cyan500}
+                    bottomSeparator={false}
+                    style={{
+                      paddingHorizontal: spacing.small,
+                    }}
+                  />
+                }
+              >
+                <ListItem
+                  text="Demo"
+                  leftIcon="DumbbellIcon"
+                  leftIconColor={colors.palette.cyan500}
+                  bottomSeparator={true}
+                  style={$sectionButton}
+                />
+              </TouchablePopupHandler>
               {/* <ListItem
                 text="Demos"
                 leftIcon="TestTube2"

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -471,6 +471,8 @@ PODS:
     - React-Core
   - RNGestureHandler (2.9.0):
     - React-Core
+  - RNReactNativeHapticFeedback (2.0.3):
+    - React-Core
   - RNReanimated (2.14.4):
     - DoubleConversion
     - FBLazyVector
@@ -590,6 +592,7 @@ DEPENDENCIES:
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - "RNFlashList (from `../node_modules/@shopify/flash-list`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
+  - RNReactNativeHapticFeedback (from `../node_modules/react-native-haptic-feedback`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNSVG (from `../node_modules/react-native-svg`)
@@ -726,6 +729,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@shopify/flash-list"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
+  RNReactNativeHapticFeedback:
+    :path: "../node_modules/react-native-haptic-feedback"
   RNReanimated:
     :path: "../node_modules/react-native-reanimated"
   RNScreens:
@@ -805,6 +810,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: 8616bd5a58af409453ea4e1b246521bb76578d60
   RNFlashList: ade81b4e928ebd585dd492014d40fb8d0e848aab
   RNGestureHandler: 071d7a9ad81e8b83fe7663b303d132406a7d8f39
+  RNReactNativeHapticFeedback: afa5bf2794aecbb2dba2525329253da0d66656df
   RNReanimated: cc5e3aa479cb9170bcccf8204291a6950a3be128
   RNScreens: 218801c16a2782546d30bd2026bb625c0302d70f
   RNSVG: 07dbd870b0dcdecc99b3a202fa37c8ca163caec2

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "react-native-auto-height-image": "^3.2.4",
     "react-native-bootsplash": "4.5.0",
     "react-native-gesture-handler": "~2.9.0",
+    "react-native-haptic-feedback": "^2.0.3",
     "react-native-image-picker": "^5.4.2",
     "react-native-quick-sqlite": "^8.0.2",
     "react-native-reanimated": "~2.14.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11143,6 +11143,11 @@ react-native-gradle-plugin@^0.71.18:
   resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.71.19.tgz#3379e28341fcd189bc1f4691cefc84c1a4d7d232"
   integrity sha512-1dVk9NwhoyKHCSxcrM6vY6cxmojeATsBobDicX0ZKr7DgUF2cBQRTKsimQFvzH8XhOVXyH8p4HyDSZNIFI8OlQ==
 
+react-native-haptic-feedback@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/react-native-haptic-feedback/-/react-native-haptic-feedback-2.0.3.tgz#09133b2175503831c04798cb0dc63ae91e3959c1"
+  integrity sha512-7+qvcxXZts/hA+HOOIFyM1x9m9fn/TJVSTgXaoQ8uT4gLc97IMvqHQ559tDmnlth+hHMzd3HRMpmRLWoKPL0DA==
+
 react-native-image-picker@^5.4.2:
   version "5.4.2"
   resolved "https://registry.yarnpkg.com/react-native-image-picker/-/react-native-image-picker-5.4.2.tgz#017d6b379cddf706acd7feb8222c2eb58e57eb8d"


### PR DESCRIPTION
The main goal of this Pull Request is to introduce Blurred Popup management. 
In order to accomplish this, the trick is to use the new React Native Skia feature ([makeImageFromView](https://shopify.github.io/react-native-skia/docs/snapshotviews/#creating-snapshots-of-views)). 

Basically, the steps used are as follows: 

1. A SnapShot is taken (via React Native Skia) of the currently displayed screen 
2. It is converted into a Skia Image 
3. Two Image layers are added, one with a strong Blur and one with a softer Blur (since the first one will not be enough to cover the whole screen); 
4. The Popup with the options is loaded, via a fading animation that takes advantage of a SharedValue Reanimated

All the described flow is handled by two components: 
1. **BlurredPopupProvider**: Wraps the whole app and is responsible for the logic of loading the popup 
2. **TouchablePopupHandler**: Component with which to wrap all components in correspondence of which you want to trigger the popup display (on Long Press). 


![photo_2023-07-03 18 12 23](https://github.com/ArcadeLabsInc/arcade/assets/37193302/cb42b694-ddb2-4cc1-9b84-65797e01147d)
