### PR TITLE
Fix errors and optimize

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -24,6 +24,7 @@ import { setupReactotron } from "./services/reactotron"
 import Config from "./config"
 import { RelayProvider } from "./components/RelayProvider"
 import { GestureHandlerRootView } from "react-native-gesture-handler"
+import { QueryClient, QueryClientProvider } from "react-query"
 
 // Set up Reactotron, which is a free desktop app for inspecting and debugging
 // React Native apps. Learn more here: https://github.com/infinitered/reactotron
@@ -102,21 +103,25 @@ function App(props: AppProps) {
     config,
   }
 
+  const queryClient = new QueryClient()
+
   // otherwise, we're ready to render the app
   return (
     <SafeAreaProvider initialMetrics={initialWindowMetrics}>
       <ErrorBoundary catchErrors={Config.catchErrors}>
-        <RelayProvider>
-          <GestureHandlerRootView
-            style={{ flex: 1 /* eslint-disable-line react-native/no-inline-styles */ }}
-          >
-            <AppNavigator
-              linking={linking}
-              initialState={initialNavigationState}
-              onStateChange={onNavigationStateChange}
-            />
-          </GestureHandlerRootView>
-        </RelayProvider>
+        <QueryClientProvider client={queryClient}>
+          <RelayProvider>
+            <GestureHandlerRootView
+              style={{ flex: 1 /* eslint-disable-line react-native/no-inline-styles */ }}
+            >
+              <AppNavigator
+                linking={linking}
+                initialState={initialNavigationState}
+                onStateChange={onNavigationStateChange}
+              />
+            </GestureHandlerRootView>
+          </RelayProvider>
+        </QueryClientProvider>
       </ErrorBoundary>
     </SafeAreaProvider>
   )

--- a/app/components/ChannelMessageForm.tsx
+++ b/app/components/ChannelMessageForm.tsx
@@ -77,7 +77,10 @@ export function ChannelMessageForm({
 
   const createEvent = async (data) => {
     // no popup here please
-    if (!attached && data.content.length === 0) return
+    if (!attached && data.content.length === 0) {
+      alert("Message cannot be empty")
+      return
+    }
 
     let content = data.content
     if (attached) {

--- a/app/components/ContactItem.tsx
+++ b/app/components/ContactItem.tsx
@@ -1,39 +1,35 @@
-import React, { useContext, useEffect, useState } from "react"
+import React, { useContext } from "react"
 import { AutoImage, RelayContext, Text } from "app/components"
 import { ImageStyle, TextStyle, View, ViewStyle } from "react-native"
 import { spacing } from "app/theme"
 import { shortenKey } from "app/utils/shortenKey"
 import { NostrPool } from "app/arclib/src"
+import { useQuery } from "react-query"
 
 export function ContactItem({ pubkey, fallback }: { pubkey: string; fallback?: string }) {
   const pool = useContext(RelayContext) as NostrPool
-  const [metadata, setMetadata] = useState(null)
 
-  useEffect(() => {
-    async function fetchProfile() {
-      if (fallback) {
-        const content = JSON.parse(fallback)
-        setMetadata(content)
-      } else {
-        const list = await pool.list([{ kinds: [0], authors: [pubkey] }], true)
-        if (list.length > 0) {
-          const content = JSON.parse(list[0].content)
-          setMetadata(content)
-        }
+  const { data: profile } = useQuery(["user", pubkey], async () => {
+    if (fallback) {
+      return JSON.parse(fallback)
+    } else {
+      const list = await pool.list([{ kinds: [0], authors: [pubkey] }], true)
+      const latest = list.slice(-1)[0]
+      if (latest) {
+        return JSON.parse(latest.content)
       }
     }
-    fetchProfile().catch(console.error)
-  }, [pubkey])
+  })
 
   return (
     <View style={$item}>
       <AutoImage
-        source={{ uri: metadata?.picture || "https://void.cat/d/KmypFh2fBdYCEvyJrPiN89.webp" }}
+        source={{ uri: profile?.picture || "https://void.cat/d/KmypFh2fBdYCEvyJrPiN89.webp" }}
         style={$itemAvatar}
       />
       <View>
         <Text
-          text={metadata?.display_name || metadata?.name || "Loading..."}
+          text={profile?.display_name || profile?.username || "Loading..."}
           preset="bold"
           numberOfLines={1}
           style={$itemName}

--- a/app/components/ContactItem.tsx
+++ b/app/components/ContactItem.tsx
@@ -59,7 +59,7 @@ const $itemAvatar: ImageStyle = {
 }
 
 const $itemName: TextStyle = {
-  maxWidth: 250,
+  maxWidth: 200,
 }
 
 const $itemContent: TextStyle = {

--- a/app/components/DirectMessageForm.tsx
+++ b/app/components/DirectMessageForm.tsx
@@ -28,6 +28,9 @@ export function DirectMessageForm({
   const [value, setValue] = useState("")
 
   const imagePicker = async () => {
+    // start loading
+    setLoading(true)
+    // open image picker
     const result = await launchImageLibrary({ mediaType: "photo", selectionLimit: 1 })
     if (!result.didCancel) {
       const filename = result.assets[0].fileName
@@ -67,7 +70,10 @@ export function DirectMessageForm({
   }
 
   const submit = async () => {
-    if (!value) return
+    if (!attached && value.length === 0) {
+      alert("Message cannot be empty")
+      return
+    }
 
     let content = value
     if (attached) {
@@ -88,6 +94,8 @@ export function DirectMessageForm({
     }
     // reset state
     setValue("")
+    setAttached(null)
+    setLoading(false)
   }
 
   return (

--- a/app/components/RelayProvider.tsx
+++ b/app/components/RelayProvider.tsx
@@ -15,7 +15,7 @@ export const RelayProvider = observer(function RelayProvider({
   if (!db) throw new Error("cannot initialized db")
 
   const {
-    userStore: { getRelays, privkey, metadata, isNewUser, clearNewUser },
+    userStore: { getRelays, privkey, getMetadata, isNewUser, clearNewUser },
   } = useStores()
 
   const ident = useMemo(() => (privkey ? new ArcadeIdentity(privkey, "", "") : null), [privkey])
@@ -30,7 +30,7 @@ export const RelayProvider = observer(function RelayProvider({
       if (isNewUser) {
         console.log("creating user...")
         const res = await pool.send({
-          content: metadata,
+          content: JSON.stringify(getMetadata),
           tags: [],
           kind: 0,
         })

--- a/app/components/User.tsx
+++ b/app/components/User.tsx
@@ -1,10 +1,11 @@
-import React, { memo, useContext, useEffect, useState } from "react"
+import React, { memo, useContext } from "react"
 import { AutoImage, RelayContext, Text } from "app/components"
 import { ImageStyle, Pressable, TextStyle, View, ViewStyle } from "react-native"
 import { colors, spacing } from "app/theme"
 import { shortenKey } from "app/utils/shortenKey"
 import { useNavigation } from "@react-navigation/native"
 import { NostrPool } from "app/arclib/src"
+import { useQuery } from "react-query"
 
 interface UserProp {
   pubkey: string
@@ -15,21 +16,13 @@ export const User = memo(function User({ pubkey, reverse }: UserProp) {
   const pool = useContext(RelayContext) as NostrPool
   const navigation = useNavigation<any>()
 
-  const [profile, setProfile] = useState(null)
-
-  useEffect(() => {
-    async function fetchProfile() {
-      const list = await pool.list([{ kinds: [0], authors: [pubkey] }], true)
-      const latest = list.slice(-1)[0]
-      if (latest) {
-        const content = JSON.parse(latest.content)
-        setProfile(content)
-      } else {
-        console.log("user profile not found", pubkey)
-      }
+  const { data: profile } = useQuery(["user", pubkey], async () => {
+    const list = await pool.list([{ kinds: [0], authors: [pubkey] }], true)
+    const latest = list.slice(-1)[0]
+    if (latest) {
+      return JSON.parse(latest.content)
     }
-    fetchProfile().catch(console.error)
-  }, [pubkey])
+  })
 
   return (
     <>

--- a/app/components/User.tsx
+++ b/app/components/User.tsx
@@ -6,13 +6,15 @@ import { shortenKey } from "app/utils/shortenKey"
 import { useNavigation } from "@react-navigation/native"
 import { NostrPool } from "app/arclib/src"
 import { useQuery } from "react-query"
+import { VenetianMaskIcon } from "lucide-react-native"
 
 interface UserProp {
   pubkey: string
   reverse?: boolean
+  blinded?: boolean
 }
 
-export const User = memo(function User({ pubkey, reverse }: UserProp) {
+export const User = memo(function User({ pubkey, reverse, blinded }: UserProp) {
   const pool = useContext(RelayContext) as NostrPool
   const navigation = useNavigation<any>()
 
@@ -31,6 +33,11 @@ export const User = memo(function User({ pubkey, reverse }: UserProp) {
           source={{ uri: profile?.picture || "https://void.cat/d/HxXbwgU9ChcQohiVxSybCs.jpg" }}
           style={$userAvatar}
         />
+        {blinded && (
+          <View style={$blinded}>
+            <VenetianMaskIcon width={20} height={20} color={colors.palette.cyan500} />
+          </View>
+        )}
       </Pressable>
       <View style={reverse ? $userTitleReverse : $userTitle}>
         <Text
@@ -47,6 +54,12 @@ export const User = memo(function User({ pubkey, reverse }: UserProp) {
 
 const $user: ViewStyle = {
   flexShrink: 0,
+  position: "relative",
+}
+
+const $blinded: ViewStyle = {
+  alignSelf: "center",
+  marginTop: spacing.tiny,
 }
 
 const $userAvatar: ImageStyle = {

--- a/app/models/Contact.ts
+++ b/app/models/Contact.ts
@@ -10,6 +10,7 @@ export const ContactModel = types
     pubkey: types.string,
     secret: types.boolean,
     legacy: types.boolean,
+    metadata: types.maybeNull(types.string),
   })
   .actions(withSetPropAction)
   .views((self) => ({})) // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/app/models/UserStore.ts
+++ b/app/models/UserStore.ts
@@ -287,6 +287,11 @@ export const UserStoreModel = types
       }
       self.privMessages = cast(uniqueList)
     }),
+    fetchMetadata: flow(function* () {
+      const ident = new ArcadeIdentity(self.privkey)
+      const { profile } = yield getProfile(ident, self.pubkey)
+      self.setProp("metadata", profile)
+    }),
     updateMetadata: flow(function* (data: Profile & PrivateSettings, profmgr?: ProfileManager) {
       if (profmgr) {
         yield updateProfile(profmgr, data)

--- a/app/models/UserStore.ts
+++ b/app/models/UserStore.ts
@@ -202,8 +202,13 @@ export const UserStoreModel = types
       const res = yield mgr.list()
       self.setProp("contacts", res)
     }),
-    addContact: flow(function* (contact: Contact, mgr: ContactManager) {
+    addContact: flow(function* (
+      contact: Contact & { metadata?: string },
+      mgr: ContactManager,
+      metadata?: string,
+    ) {
       yield mgr.add(contact)
+      if (metadata) contact.metadata = metadata
       const index = self.contacts.findIndex(
         (el: { pubkey: string }) => el.pubkey === contact.pubkey,
       )

--- a/app/models/UserStore.ts
+++ b/app/models/UserStore.ts
@@ -197,13 +197,11 @@ export const UserStoreModel = types
         contacts: [],
       })
     },
-    async fetchContacts(mgr: ContactManager) {
+    fetchContacts: flow(function* (mgr: ContactManager) {
       if (!self.pubkey) throw new Error("pubkey not found")
-      const res = await mgr.list()
-      runInAction(() => {
-        self.setProp("contacts", res)
-      })
-    },
+      const res = yield mgr.list()
+      self.setProp("contacts", res)
+    }),
     addContact: flow(function* (contact: Contact, mgr: ContactManager) {
       yield mgr.add(contact)
       const index = self.contacts.findIndex(

--- a/app/screens/AddContactScreen.tsx
+++ b/app/screens/AddContactScreen.tsx
@@ -21,7 +21,7 @@ import {
   BottomSheetView,
 } from "@gorhom/bottom-sheet"
 import { useStores } from "app/models"
-import { useContactManager, useUserContacts } from "app/utils/useUserContacts"
+import { useContactManager } from "app/utils/useUserContacts"
 import { nip19 } from "nostr-tools"
 import { FlashList } from "@shopify/flash-list"
 
@@ -41,10 +41,8 @@ export const AddContactScreen: FC<AddContactScreenProps> = observer(function Add
   const bottomSheetModalRef = useRef<BottomSheetModal>(null)
   const snapPoints = useMemo(() => ["36%", "50%"], [])
 
-  const contacts = useUserContacts()
-
   const {
-    userStore: { addContact, removeContact },
+    userStore: { contacts, addContact, removeContact },
   } = useStores()
 
   // Pull in navigation via hook

--- a/app/screens/AddContactScreen.tsx
+++ b/app/screens/AddContactScreen.tsx
@@ -119,7 +119,13 @@ export const AddContactScreen: FC<AddContactScreenProps> = observer(function Add
             </Pressable>
           ) : (
             <Pressable
-              onPress={() => addContact({ pubkey: item.pubkey, legacy: true, secret: false }, mgr)}
+              onPress={() =>
+                addContact(
+                  { pubkey: item.pubkey, legacy: true, secret: false },
+                  mgr,
+                  item.profile.content,
+                )
+              }
             >
               <Text text="Add" size="xs" />
             </Pressable>

--- a/app/screens/AddContactScreen.tsx
+++ b/app/screens/AddContactScreen.tsx
@@ -17,8 +17,8 @@ import { colors, spacing } from "app/theme"
 import {
   BottomSheetModal,
   BottomSheetModalProvider,
-  BottomSheetScrollView,
   BottomSheetTextInput,
+  BottomSheetView,
 } from "@gorhom/bottom-sheet"
 import { useStores } from "app/models"
 import { useContactManager, useUserContacts } from "app/utils/useUserContacts"
@@ -132,7 +132,7 @@ export const AddContactScreen: FC<AddContactScreenProps> = observer(function Add
 
   return (
     <BottomSheetModalProvider>
-      <Screen contentContainerStyle={$root} preset="fixed" keyboardOffset={50}>
+      <Screen contentContainerStyle={$root} preset="fixed">
         <View style={$heading}>
           <Text text="Suggestions" size="lg" preset="bold" />
         </View>
@@ -162,9 +162,10 @@ export const AddContactScreen: FC<AddContactScreenProps> = observer(function Add
         snapPoints={snapPoints}
         enablePanDownToClose={true}
         backgroundStyle={$modal}
+        keyboardBehavior="fillParent"
         handleIndicatorStyle={{ backgroundColor: colors.palette.cyan700 }}
       >
-        <BottomSheetScrollView style={$modalContent}>
+        <BottomSheetView style={$modalContent}>
           <Text preset="bold" size="lg" text="Add contact" style={$modalHeader} />
           <View style={$modalForm}>
             <View style={$formInputGroup}>
@@ -187,7 +188,7 @@ export const AddContactScreen: FC<AddContactScreenProps> = observer(function Add
               onPress={() => addCustomContact()}
             />
           </View>
-        </BottomSheetScrollView>
+        </BottomSheetView>
       </BottomSheetModal>
     </BottomSheetModalProvider>
   )
@@ -227,7 +228,6 @@ const $modalHeader: ViewStyle = {
 const $modalContent: ViewStyle = {
   flex: 1,
   paddingHorizontal: spacing.large,
-  marginBottom: spacing.extraLarge,
 }
 
 const $modalForm: ViewStyle = {

--- a/app/screens/AddContactScreen.tsx
+++ b/app/screens/AddContactScreen.tsx
@@ -42,7 +42,7 @@ export const AddContactScreen: FC<AddContactScreenProps> = observer(function Add
   const snapPoints = useMemo(() => ["36%", "50%"], [])
 
   const {
-    userStore: { contacts, addContact, removeContact },
+    userStore: { getContacts, addContact, removeContact },
   } = useStores()
 
   // Pull in navigation via hook
@@ -58,10 +58,9 @@ export const AddContactScreen: FC<AddContactScreenProps> = observer(function Add
       if (pubkey.substring(0, 4) === "npub") {
         pubkey = nip19.decode(pubkey).data.toString()
       }
-      if (/[a-f0-9]{64}/.test(pubkey) && !contacts.find((el) => el.pubkey === pubkey)) {
+      if (/[a-f0-9]{64}/.test(pubkey) && !getContacts.find((el) => el.pubkey === pubkey)) {
         try {
           addContact({ pubkey, legacy: true, secret: false }, mgr)
-          navigation.goBack()
         } catch (e) {
           alert(`Invalid contact: ${e}`)
         }
@@ -108,25 +107,28 @@ export const AddContactScreen: FC<AddContactScreenProps> = observer(function Add
     fetchSuggestion()
   }, [])
 
-  const renderItem = useCallback(({ item }) => {
-    const added = contacts.find((e) => e.pubkey === item.pubkey)
-    return (
-      <View style={$item}>
-        <ContactItem pubkey={item.pubkey} fallback={item.profile.content} />
-        {added ? (
-          <Pressable onPress={() => removeContact(item.pubkey, mgr)}>
-            <Text text="Remove" size="xs" />
-          </Pressable>
-        ) : (
-          <Pressable
-            onPress={() => addContact({ pubkey: item.pubkey, legacy: true, secret: false }, mgr)}
-          >
-            <Text text="Add" size="xs" />
-          </Pressable>
-        )}
-      </View>
-    )
-  }, [])
+  const renderItem = useCallback(
+    ({ item }) => {
+      const added = getContacts.find((e) => e.pubkey === item.pubkey)
+      return (
+        <View style={$item}>
+          <ContactItem pubkey={item.pubkey} fallback={item.profile.content} />
+          {added ? (
+            <Pressable onPress={() => removeContact(item.pubkey, mgr)}>
+              <Text text="Remove" size="xs" />
+            </Pressable>
+          ) : (
+            <Pressable
+              onPress={() => addContact({ pubkey: item.pubkey, legacy: true, secret: false }, mgr)}
+            >
+              <Text text="Add" size="xs" />
+            </Pressable>
+          )}
+        </View>
+      )
+    },
+    [getContacts],
+  )
 
   return (
     <BottomSheetModalProvider>
@@ -143,6 +145,7 @@ export const AddContactScreen: FC<AddContactScreenProps> = observer(function Add
         ) : (
           <FlashList
             data={data.profiles}
+            extraData={getContacts}
             keyExtractor={(item: { pubkey: string }) => item.pubkey}
             renderItem={renderItem}
             ListEmptyComponent={

--- a/app/screens/ChannelManagerScreen.tsx
+++ b/app/screens/ChannelManagerScreen.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties, FC, useContext, useLayoutEffect, useMemo } from "react"
 import { observer } from "mobx-react-lite"
-import { Pressable, View, ViewStyle } from "react-native"
+import { Alert, Pressable, View, ViewStyle } from "react-native"
 import { NativeStackScreenProps } from "@react-navigation/native-stack"
 import { AppStackScreenProps } from "app/navigators"
 import { Header, RelayContext, Screen, Text } from "app/components"
@@ -29,8 +29,17 @@ export const ChannelManagerScreen: FC<ChannelManagerScreenProps> = observer(
     const navigation = useNavigation<any>()
 
     const leave = (id: string) => {
-      console.log("leaving: ", id)
-      leaveChannel(id)
+      Alert.alert("Confirm leave channel", "Are you sure?", [
+        {
+          text: "Cancel",
+        },
+        {
+          text: "Confirm",
+          onPress: () => {
+            leaveChannel(id)
+          },
+        },
+      ])
     }
 
     const invite = (info: { id: string; name: string; privkey: string }) => {

--- a/app/screens/ContactsScreen.tsx
+++ b/app/screens/ContactsScreen.tsx
@@ -7,7 +7,7 @@ import { ContactItem, Header, Screen, Text } from "app/components"
 import { useNavigation } from "@react-navigation/native"
 import { colors, spacing } from "app/theme"
 import { FlashList } from "@shopify/flash-list"
-import { useContactManager, useUserContacts } from "app/utils/useUserContacts"
+import { useContactManager } from "app/utils/useUserContacts"
 import { UserMinus, Globe } from "lucide-react-native"
 import { useStores } from "app/models"
 import { Contact } from "app/arclib/src/contacts"
@@ -16,14 +16,14 @@ interface ContactsScreenProps extends NativeStackScreenProps<AppStackScreenProps
 
 export const ContactsScreen: FC<ContactsScreenProps> = observer(function ContactsScreen() {
   const mgr = useContactManager()
-  const contacts = useUserContacts()
+  // const contacts = useUserContacts()
 
   // Pull in navigation via hook
   const navigation = useNavigation<any>()
 
   // Stores
   const {
-    userStore: { removeContact },
+    userStore: { contacts, removeContact },
   } = useStores()
 
   const unfollow = (pubkey: string) => {

--- a/app/screens/ContactsScreen.tsx
+++ b/app/screens/ContactsScreen.tsx
@@ -23,7 +23,7 @@ export const ContactsScreen: FC<ContactsScreenProps> = observer(function Contact
 
   // Stores
   const {
-    userStore: { contacts, fetchContacts, removeContact },
+    userStore: { getContacts, fetchContacts, removeContact },
   } = useStores()
 
   const unfollow = (pubkey: string) => {
@@ -67,7 +67,7 @@ export const ContactsScreen: FC<ContactsScreenProps> = observer(function Contact
   return (
     <Screen style={$root} preset="scroll">
       <FlashList
-        data={contacts}
+        data={getContacts}
         keyExtractor={(item) => item.pubkey}
         renderItem={renderItem}
         ListEmptyComponent={

--- a/app/screens/ContactsScreen.tsx
+++ b/app/screens/ContactsScreen.tsx
@@ -23,11 +23,15 @@ export const ContactsScreen: FC<ContactsScreenProps> = observer(function Contact
 
   // Stores
   const {
-    userStore: { contacts, removeContact },
+    userStore: { contacts, fetchContacts, removeContact },
   } = useStores()
 
   const unfollow = (pubkey: string) => {
     removeContact(pubkey, mgr)
+  }
+
+  const refresh = () => {
+    fetchContacts(mgr)
   }
 
   useLayoutEffect(() => {
@@ -37,6 +41,9 @@ export const ContactsScreen: FC<ContactsScreenProps> = observer(function Contact
         <Header
           title="Contacts"
           titleStyle={{ color: colors.palette.white }}
+          leftIcon="RefreshCcw"
+          leftIconColor={colors.palette.cyan400}
+          onLeftPress={() => refresh()}
           rightIcon="Plus"
           rightIconColor={colors.palette.cyan400}
           onRightPress={() => navigation.navigate("AddContact")}

--- a/app/screens/CreateAccountScreen.tsx
+++ b/app/screens/CreateAccountScreen.tsx
@@ -132,7 +132,7 @@ export const CreateAccountScreen: FC<CreateAccountScreenProps> = observer(
           ) : (
             <ActivityIndicator
               color={colors.palette.white}
-              animating={loading}
+              animating={pickerLoading}
               style={$avatarButton}
             />
           )}

--- a/app/screens/CreateAccountScreen.tsx
+++ b/app/screens/CreateAccountScreen.tsx
@@ -22,6 +22,12 @@ import { ImagePlusIcon } from "lucide-react-native"
 interface CreateAccountScreenProps
   extends NativeStackScreenProps<AppStackScreenProps<"CreateAccount">> {}
 
+interface ISignup {
+  displayName: string
+  username: string
+  about: string
+}
+
 export const CreateAccountScreen: FC<CreateAccountScreenProps> = observer(
   function CreateAccountScreen() {
     const formikRef = useRef(null)
@@ -76,14 +82,17 @@ export const CreateAccountScreen: FC<CreateAccountScreenProps> = observer(
       }
     }
 
-    const signup = (data: { displayName: string; username: string; about: string }) => {
+    const signup = async (data: ISignup) => {
       if (!data.username) {
         alert("Username is required")
       } else if (!/^[0-9a-zA-Z_.-]+$/.test(data.username)) {
         alert("Username is invalid, please check again")
       } else {
         setLoading(true)
-        userStore.signup(picture, data.username, data.displayName, data.about)
+        await userStore.signup(picture, data.username, data.displayName, data.about).catch((e) => {
+          alert(e)
+          setLoading(false)
+        })
       }
     }
 

--- a/app/screens/CreateChannelScreen.tsx
+++ b/app/screens/CreateChannelScreen.tsx
@@ -73,7 +73,8 @@ export const CreateChannelScreen: FC<CreateChannelScreenProps> = observer(
 
     const createChannel = async (data: any) => {
       try {
-        if (!data.name) {
+        const channelName = data.name.trim()
+        if (channelName.length < 1) {
           alert("Channel name is required")
         } else {
           const fullData: ChannelInfo = { ...data, picture }

--- a/app/screens/DirectMessageScreen.tsx
+++ b/app/screens/DirectMessageScreen.tsx
@@ -101,9 +101,8 @@ export const DirectMessageScreen: FC<DirectMessageScreenProps> = observer(
         if (item.pubkey === pubkey) {
           return (
             <View style={$messageItemReverse}>
-              <User pubkey={item.pubkey} reverse={true} />
+              <User pubkey={item.pubkey} reverse={true} blinded={item.blinded} />
               <View style={$messageContentWrapperReverse}>
-                {item.blinded && <Text style={$blindedIconLeft}>🕶️</Text>}
                 <MessageContent content={content} />
                 <View style={$createdAt}>
                   <Text text={createdAt} preset="default" size="xs" style={$createdAtText} />
@@ -114,8 +113,7 @@ export const DirectMessageScreen: FC<DirectMessageScreenProps> = observer(
         } else {
           return (
             <View style={$messageItem}>
-              {item.blinded && <Text style={$blindedIconRight}>🕶️</Text>}
-              <User pubkey={item.pubkey} />
+              <User pubkey={item.pubkey} blinded={item.blinded} />
               <View style={$messageContentWrapper}>
                 <MessageContent content={content} />
                 <View style={$createdAt}>
@@ -235,18 +233,4 @@ const $createdAtText: TextStyle = {
 const $emptyState: ViewStyle = {
   alignSelf: "center",
   paddingVertical: spacing.medium,
-}
-
-const $blindedIconLeft: TextStyle = {
-  position: "absolute",
-  top: 5,
-  right: 5,
-  fontSize: 20,
-}
-
-const $blindedIconRight: TextStyle = {
-  position: "absolute",
-  top: 5,
-  right: 15,
-  fontSize: 20,
 }

--- a/app/screens/EditProfileScreen.tsx
+++ b/app/screens/EditProfileScreen.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useEffect, useLayoutEffect, useRef, useState } from "react"
+import React, { FC, useContext, useLayoutEffect, useRef, useState } from "react"
 import { observer } from "mobx-react-lite"
 import { ActivityIndicator, ImageStyle, Platform, Pressable, View, ViewStyle } from "react-native"
 import { NativeStackScreenProps } from "@react-navigation/native-stack"
@@ -13,7 +13,7 @@ import { Profile, ProfileManager } from "app/arclib/src/profile"
 import { NostrPool } from "app/arclib/src"
 import { ImagePlusIcon } from "lucide-react-native"
 import { launchImageLibrary } from "react-native-image-picker"
-import { PrivateSettings, updateProfile } from "./NotificationSettingScreen"
+import { PrivateSettings } from "app/utils/profile"
 
 interface EditProfileScreenProps
   extends NativeStackScreenProps<AppStackScreenProps<"EditProfile">> {}
@@ -25,11 +25,12 @@ export const EditProfileScreen: FC<EditProfileScreenProps> = observer(function E
   const formikRef = useRef(null)
 
   const [picture, setPicture] = useState(null)
-  const [profile, setProfile] = useState(null)
   const [loading, setLoading] = useState(false)
 
   // Pull in one of our MST stores
-  const { userStore } = useStores()
+  const {
+    userStore: { metadata, updateMetadata },
+  } = useStores()
 
   // Pull in navigation via hook
   const navigation = useNavigation<any>()
@@ -76,7 +77,7 @@ export const EditProfileScreen: FC<EditProfileScreenProps> = observer(function E
 
   const updateSettings = async (data: Profile & PrivateSettings) => {
     try {
-      await updateProfile(profmgr, data)
+      updateMetadata(data, profmgr)
     } catch (e) {
       alert(`Failed to save settings: ${e}`)
     }
@@ -97,19 +98,6 @@ export const EditProfileScreen: FC<EditProfileScreenProps> = observer(function E
     })
   }, [])
 
-  useEffect(() => {
-    async function fetchProfile() {
-      const content = await profmgr.load()
-      if (content) {
-        setProfile(content)
-      } else {
-        console.log("user profile not found", userStore.pubkey)
-      }
-    }
-
-    fetchProfile().catch(console.error)
-  }, [userStore.pubkey])
-
   return (
     <Screen
       preset="scroll"
@@ -124,7 +112,7 @@ export const EditProfileScreen: FC<EditProfileScreenProps> = observer(function E
       <View style={$avatar}>
         <AutoImage
           source={{
-            uri: picture || profile?.picture || "https://void.cat/d/HxXbwgU9ChcQohiVxSybCs.jpg",
+            uri: picture || metadata.picture,
           }}
           style={[$image, $avatarImage]}
         />
@@ -144,16 +132,16 @@ export const EditProfileScreen: FC<EditProfileScreenProps> = observer(function E
         innerRef={formikRef}
         enableReinitialize={true}
         initialValues={{
-          display_name: profile?.display_name || "",
-          name: profile?.name || "",
-          username: profile?.username || "",
-          picture: picture || profile?.picture,
-          banner: profile?.banner || "",
-          about: profile?.about || "",
-          privchat_push_enabled: profile?.privchat_push_enabled || false,
-          channel_push_enabled: profile?.channel_push_enabled || false,
-          buyoffer_push_enabled: profile?.buyoffer_push_enabled || false,
-          selloffer_push_enabled: profile?.selloffer_push_enabled || false,
+          display_name: metadata.display_name,
+          username: metadata.username,
+          nip05: metadata.nip05,
+          picture: picture || metadata.picture,
+          banner: metadata.banner,
+          about: metadata.about,
+          privchat_push_enabled: metadata.privchat_push_enabled,
+          channel_push_enabled: metadata.channel_push_enabled,
+          buyoffer_push_enabled: metadata.channel_push_enabled,
+          selloffer_push_enabled: metadata.channel_push_enabled,
         }}
         onSubmit={(values) => updateSettings(values)}
       >
@@ -170,22 +158,22 @@ export const EditProfileScreen: FC<EditProfileScreenProps> = observer(function E
               autoFocus={false}
             />
             <TextField
-              label="Name"
-              style={$input}
-              inputWrapperStyle={$inputWrapper}
-              onChangeText={handleChange("name")}
-              onBlur={handleBlur("name")}
-              value={values.name}
-              autoCapitalize="none"
-              autoFocus={false}
-            />
-            <TextField
               label="Username"
               style={$input}
               inputWrapperStyle={$inputWrapper}
               onChangeText={handleChange("username")}
               onBlur={handleBlur("username")}
               value={values.username}
+              autoCapitalize="none"
+              autoFocus={false}
+            />
+            <TextField
+              label="NIP-05"
+              style={$input}
+              inputWrapperStyle={$inputWrapper}
+              onChangeText={handleChange("displayName")}
+              onBlur={handleBlur("displayName")}
+              value={values.nip05}
               autoCapitalize="none"
               autoFocus={false}
             />

--- a/app/screens/EditProfileScreen.tsx
+++ b/app/screens/EditProfileScreen.tsx
@@ -77,7 +77,7 @@ export const EditProfileScreen: FC<EditProfileScreenProps> = observer(function E
 
   const updateSettings = async (data: Profile & PrivateSettings) => {
     try {
-      updateMetadata(data, profmgr)
+      updateMetadata(data, profmgr).then(() => navigation.navigate("Profile"))
     } catch (e) {
       alert(`Failed to save settings: ${e}`)
     }

--- a/app/screens/LoginScreen.tsx
+++ b/app/screens/LoginScreen.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useLayoutEffect, useState } from "react"
 import { observer } from "mobx-react-lite"
-import { Pressable, TextStyle, View, ViewStyle } from "react-native"
+import { ActivityIndicator, Pressable, TextStyle, View, ViewStyle } from "react-native"
 import { NativeStackScreenProps } from "@react-navigation/native-stack"
 import { AppStackScreenProps } from "app/navigators"
 import { Button, Header, Screen, Text, TextField } from "app/components"
@@ -15,6 +15,7 @@ interface LoginScreenProps extends NativeStackScreenProps<AppStackScreenProps<"L
 export const LoginScreen: FC<LoginScreenProps> = observer(function LoginScreen() {
   const [nsec, setNsec] = useState("")
   const [secure, setSecure] = useState(true)
+  const [loading, setLoading] = useState(false)
 
   // Pull in one of our MST stores
   const { userStore } = useStores()
@@ -24,11 +25,18 @@ export const LoginScreen: FC<LoginScreenProps> = observer(function LoginScreen()
 
   // login
   const login = () => {
-    let accessKey = nsec
-    if (!accessKey.startsWith("nsec")) {
-      accessKey = nip19.nsecEncode(accessKey)
+    if (!nsec && nsec.length < 60) {
+      alert("access key as nsec or hexstring is required")
+    } else {
+      setLoading(true)
+
+      let accessKey = nsec
+      if (!accessKey.startsWith("nsec")) {
+        accessKey = nip19.nsecEncode(accessKey)
+      }
+
+      userStore.loginWithNsec(accessKey)
     }
-    userStore.loginWithNsec(accessKey)
   }
 
   useLayoutEffect(() => {
@@ -75,7 +83,13 @@ export const LoginScreen: FC<LoginScreenProps> = observer(function LoginScreen()
             )}
           </Pressable>
         </View>
-        <Button text="Enter" onPress={login} style={$button} pressedStyle={$button} />
+        <View style={$formButtonGroup}>
+          {loading ? (
+            <ActivityIndicator color={colors.palette.cyan500} animating={loading} />
+          ) : (
+            <Button text="Enter" onPress={login} style={$button} pressedStyle={$button} />
+          )}
+        </View>
       </View>
     </Screen>
   )
@@ -141,4 +155,13 @@ const $button: ViewStyle = {
   marginVertical: spacing.medium,
   height: 50,
   minHeight: 50,
+}
+
+const $formButtonGroup: ViewStyle = {
+  flexDirection: "row",
+  alignItems: "center",
+  justifyContent: "center",
+  height: 50,
+  minHeight: 50,
+  marginVertical: spacing.medium,
 }

--- a/app/screens/NotificationSettingScreen.tsx
+++ b/app/screens/NotificationSettingScreen.tsx
@@ -7,23 +7,13 @@ import { Button, Header, ListItem, RelayContext, Screen, Text, Toggle } from "ap
 import { useNavigation } from "@react-navigation/native"
 import { colors, spacing } from "app/theme"
 import { NostrPool } from "app/arclib/src"
-import { ProfileManager, Profile } from "app/arclib/src/profile"
+import { ProfileManager } from "app/arclib/src/profile"
 import { useStores } from "app/models"
 import { Formik } from "formik"
-import { registerForPushNotifications } from "app/utils/notification"
+import { PrivateSettings, updateProfile } from "app/utils/profile"
 
 interface NotificationSettingScreenProps
   extends NativeStackScreenProps<AppStackScreenProps<"NotificationSetting">> {}
-
-// good to have a few non-arcade backups
-const ARCADE_RELAYS = [
-  "wss://relay.arcade.city",
-  "wss://arc1.arcadelabs.co",
-  "wss://relay.damus.io",
-  "wss://nos.lol",
-]
-
-const ARCADE_PUBKEY = "c4899d1312a7ccf42cc4bfd0559826d20f7564293de4588cb8b089a574d71757"
 
 export const NotificationSettingScreen: FC<NotificationSettingScreenProps> = observer(
   function NotificationSettingScreen() {
@@ -195,64 +185,4 @@ const $button: ViewStyle = {
   marginBottom: spacing.small,
   height: 50,
   minHeight: 50,
-}
-
-export type PrivateSettings = {
-  privchat_push_enabled: boolean
-  channel_push_enabled: boolean
-  buyoffer_push_enabled: boolean
-  selloffer_push_enabled: boolean
-}
-
-export async function updateProfile(profmgr: ProfileManager, profile: Profile & PrivateSettings) {
-  // save public and private settings
-  await profmgr.save(profile, [
-    "privchat_push_enabled",
-    "channel_push_enabled",
-    "buyoffer_push_enabled",
-    "selloffer_push_enabled",
-  ])
-
-  // update arcade push notification settings
-  if (
-    profile.privchat_push_enabled ||
-    profile.channel_push_enabled ||
-    profile.buyoffer_push_enabled ||
-    profile.selloffer_push_enabled
-  ) {
-    const pool = profmgr.pool
-    const token = await registerForPushNotifications()
-
-    const pushSettings = {
-      pubkey: pool.ident.pubKey,
-      token,
-      privchat_push_enabled: profile.privchat_push_enabled,
-      channel_push_enabled: profile.channel_push_enabled,
-      buyoffer_push_enabled: profile.buyoffer_push_enabled,
-      selloffer_push_enabled: profile.selloffer_push_enabled,
-    }
-
-    const tmpPool = new NostrPool(pool.ident)
-    await tmpPool.setRelays(ARCADE_RELAYS)
-
-    // change to nip44 once that merges
-    const content = await pool.ident.nip04XEncrypt(
-      pool.ident.privKey,
-      ARCADE_PUBKEY,
-      JSON.stringify(pushSettings),
-    )
-
-    // use replceable event
-    await tmpPool.send({
-      kind: 30199,
-      content,
-      tags: [
-        ["d", "arcade-push"],
-        ["p", ARCADE_PUBKEY],
-      ],
-    })
-
-    // close tmp pool
-    tmpPool.close()
-  }
 }

--- a/app/screens/PrivacySettingScreen.tsx
+++ b/app/screens/PrivacySettingScreen.tsx
@@ -107,7 +107,7 @@ export const PrivacySettingScreen: FC<PrivacySettingScreenProps> = observer(
               </View>
               <View>
                 <Text
-                  text="Currently, this feature only supported by Arcade and not it compatible with other clients"
+                  text="Currently, this feature only supported by Arcade and not it compatible with other clients."
                   size="sm"
                   style={$desc}
                 />

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react"
+import React, { FC, useEffect } from "react"
 import { observer } from "mobx-react-lite"
 import {
   ImageStyle,
@@ -26,18 +26,24 @@ interface ProfileScreenProps extends NativeStackScreenProps<AppStackScreenProps<
 export const ProfileScreen: FC<ProfileScreenProps> = observer(function ProfileScreen() {
   // Pull in one of our MST stores
   const {
-    userStore: { pubkey, metadata, logout },
+    userStore: { pubkey, metadata, fetchMetadata, logout },
   } = useStores()
 
   // Pull in navigation via hook
   const navigation = useNavigation<any>()
+
+  useEffect(() => {
+    if (!metadata) {
+      fetchMetadata()
+    }
+  }, [])
 
   return (
     <Screen style={$root} preset="scroll">
       <View style={$cover}>
         <AutoImage
           source={{
-            uri: metadata.banner,
+            uri: metadata?.banner,
           }}
           style={$image}
         />
@@ -47,7 +53,7 @@ export const ProfileScreen: FC<ProfileScreenProps> = observer(function ProfileSc
           <View style={$avatar}>
             <AutoImage
               source={{
-                uri: metadata.picture,
+                uri: metadata?.picture,
               }}
               style={[$image, $avatarImage]}
             />
@@ -55,7 +61,7 @@ export const ProfileScreen: FC<ProfileScreenProps> = observer(function ProfileSc
           <Text
             preset="bold"
             size="lg"
-            text={metadata.display_name || metadata.username || "No name"}
+            text={metadata?.display_name || metadata?.username || "No name"}
             style={$userName}
           />
           <TouchableOpacity
@@ -77,14 +83,14 @@ export const ProfileScreen: FC<ProfileScreenProps> = observer(function ProfileSc
                 onPress={() => navigation.navigate("EditProfile")}
                 style={$sectionDataItem}
               >
-                <Text text={metadata.username || "No username"} />
+                <Text text={metadata?.username || "No username"} />
                 <Text text="Username" size="xs" style={$sectionDataItemSubtitle} />
               </Pressable>
               <Pressable
                 onPress={() => navigation.navigate("EditProfile")}
                 style={$sectionDataItem}
               >
-                <Text text={metadata.nip05 || "No nip-05"} />
+                <Text text={metadata?.nip05 || "No nip-05"} />
                 <Text text="NIP-05" size="xs" style={$sectionDataItemSubtitle} />
               </Pressable>
               <Pressable
@@ -92,7 +98,7 @@ export const ProfileScreen: FC<ProfileScreenProps> = observer(function ProfileSc
                 style={$sectionDataItem}
               >
                 <Text text="Bio" size="xs" style={$sectionDataItemSubtitle} />
-                <Text text={metadata.about || metadata.about || "No bio"} />
+                <Text text={metadata?.about || metadata?.about || "No bio"} />
               </Pressable>
             </View>
           </View>

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useContext, useState } from "react"
+import React, { FC } from "react"
 import { observer } from "mobx-react-lite"
 import {
   ImageStyle,
@@ -13,53 +13,31 @@ import {
 import { NativeStackScreenProps } from "@react-navigation/native-stack"
 import * as Clipboard from "expo-clipboard"
 import { AppStackScreenProps } from "app/navigators"
-import { AutoImage, Button, ListItem, RelayContext, Screen, Text } from "app/components"
+import { AutoImage, Button, ListItem, Screen, Text } from "app/components"
 import { colors, spacing } from "app/theme"
-import { useFocusEffect, useNavigation } from "@react-navigation/native"
+import { useNavigation } from "@react-navigation/native"
 import { nip19 } from "nostr-tools"
 import { useStores } from "app/models"
 import { shortenKey } from "app/utils/shortenKey"
 import { EditIcon } from "lucide-react-native"
-import { NostrPool } from "app/arclib/src"
-import { ProfileManager } from "app/arclib/src/profile"
 
 interface ProfileScreenProps extends NativeStackScreenProps<AppStackScreenProps<"Profile">> {}
 
 export const ProfileScreen: FC<ProfileScreenProps> = observer(function ProfileScreen() {
-  const pool = useContext(RelayContext) as NostrPool
-  const pmgr = new ProfileManager(pool) as ProfileManager
-
-  const [profile, setProfile] = useState(null)
-
   // Pull in one of our MST stores
-  const { userStore } = useStores()
+  const {
+    userStore: { pubkey, metadata, logout },
+  } = useStores()
 
   // Pull in navigation via hook
   const navigation = useNavigation<any>()
-
-  const logout = () => {
-    // clear user store
-    userStore.logout()
-  }
-
-  useFocusEffect(
-    useCallback(() => {
-      async function fetchProfile() {
-        const res = await pmgr.load()
-        if (res) {
-          setProfile(res)
-        }
-      }
-      fetchProfile().catch(console.error)
-    }, [userStore.pubkey]),
-  )
 
   return (
     <Screen style={$root} preset="scroll">
       <View style={$cover}>
         <AutoImage
           source={{
-            uri: profile?.banner || "https://void.cat/d/2qK2KYMPHMjMD9gcG6NZcV.jpg",
+            uri: metadata.banner,
           }}
           style={$image}
         />
@@ -69,7 +47,7 @@ export const ProfileScreen: FC<ProfileScreenProps> = observer(function ProfileSc
           <View style={$avatar}>
             <AutoImage
               source={{
-                uri: profile?.picture || "https://void.cat/d/HxXbwgU9ChcQohiVxSybCs.jpg",
+                uri: metadata.picture,
               }}
               style={[$image, $avatarImage]}
             />
@@ -77,13 +55,13 @@ export const ProfileScreen: FC<ProfileScreenProps> = observer(function ProfileSc
           <Text
             preset="bold"
             size="lg"
-            text={profile?.display_name || profile?.name || "No name"}
+            text={metadata.display_name || metadata.username || "No name"}
             style={$userName}
           />
           <TouchableOpacity
-            onPress={async () => await Clipboard.setStringAsync(nip19.npubEncode(userStore.pubkey))}
+            onPress={async () => await Clipboard.setStringAsync(nip19.npubEncode(pubkey))}
           >
-            <Text size="sm" text={shortenKey(userStore.pubkey)} style={$userNip05} />
+            <Text size="sm" text={shortenKey(pubkey)} style={$userNip05} />
           </TouchableOpacity>
         </View>
         <View style={$sections}>
@@ -99,14 +77,14 @@ export const ProfileScreen: FC<ProfileScreenProps> = observer(function ProfileSc
                 onPress={() => navigation.navigate("EditProfile")}
                 style={$sectionDataItem}
               >
-                <Text text={profile?.username || "No username"} />
+                <Text text={metadata.username || "No username"} />
                 <Text text="Username" size="xs" style={$sectionDataItemSubtitle} />
               </Pressable>
               <Pressable
                 onPress={() => navigation.navigate("EditProfile")}
                 style={$sectionDataItem}
               >
-                <Text text={profile?.nip05 || "No nip-05"} />
+                <Text text={metadata.nip05 || "No nip-05"} />
                 <Text text="NIP-05" size="xs" style={$sectionDataItemSubtitle} />
               </Pressable>
               <Pressable
@@ -114,7 +92,7 @@ export const ProfileScreen: FC<ProfileScreenProps> = observer(function ProfileSc
                 style={$sectionDataItem}
               >
                 <Text text="Bio" size="xs" style={$sectionDataItemSubtitle} />
-                <Text text={profile?.about || profile?.bio || "No bio"} />
+                <Text text={metadata.about || metadata.about || "No bio"} />
               </Pressable>
             </View>
           </View>

--- a/app/screens/RelayManagerScreen.tsx
+++ b/app/screens/RelayManagerScreen.tsx
@@ -19,8 +19,8 @@ import { PlusSquareIcon, XIcon } from "lucide-react-native"
 import {
   BottomSheetModal,
   BottomSheetModalProvider,
-  BottomSheetScrollView,
   BottomSheetTextInput,
+  BottomSheetView,
 } from "@gorhom/bottom-sheet"
 
 interface RelayManagerScreenProps
@@ -29,7 +29,7 @@ interface RelayManagerScreenProps
 export const RelayManagerScreen: FC<RelayManagerScreenProps> = observer(
   function RelayManagerScreen() {
     const bottomSheetModalRef = useRef<BottomSheetModal>(null)
-    const snapPoints = useMemo(() => ["35%", "50%"], [])
+    const snapPoints = useMemo(() => ["35%"], [])
 
     // Pull in one of our MST stores
     const {
@@ -146,7 +146,7 @@ export const RelayManagerScreen: FC<RelayManagerScreenProps> = observer(
 
     return (
       <BottomSheetModalProvider>
-        <Screen contentContainerStyle={$root} preset="fixed" keyboardOffset={50}>
+        <Screen contentContainerStyle={$root} preset="fixed">
           <SectionList
             sections={data}
             extraData={suggests}
@@ -190,9 +190,10 @@ export const RelayManagerScreen: FC<RelayManagerScreenProps> = observer(
             snapPoints={snapPoints}
             enablePanDownToClose={true}
             backgroundStyle={$modal}
+            keyboardBehavior="fillParent"
             handleIndicatorStyle={{ backgroundColor: colors.palette.cyan700 }}
           >
-            <BottomSheetScrollView style={$modalContent}>
+            <BottomSheetView style={$modalContent}>
               <Text preset="bold" size="lg" text="Add custom relay" style={$modalHeader} />
               <View style={$modalForm}>
                 <View style={$formInputGroup}>
@@ -215,7 +216,7 @@ export const RelayManagerScreen: FC<RelayManagerScreenProps> = observer(
                   onPress={() => addCustomRelay()}
                 />
               </View>
-            </BottomSheetScrollView>
+            </BottomSheetView>
           </BottomSheetModal>
         </Screen>
       </BottomSheetModalProvider>
@@ -264,12 +265,12 @@ const $modal: ViewStyle = {
 
 const $modalHeader: ViewStyle = {
   alignSelf: "center",
+  marginBottom: spacing.small,
 }
 
 const $modalContent: ViewStyle = {
   flex: 1,
   paddingHorizontal: spacing.large,
-  marginBottom: spacing.extraLarge,
 }
 
 const $modalForm: ViewStyle = {

--- a/app/screens/RelayManagerScreen.tsx
+++ b/app/screens/RelayManagerScreen.tsx
@@ -26,6 +26,8 @@ import {
 interface RelayManagerScreenProps
   extends NativeStackScreenProps<AppStackScreenProps<"RelayManager">> {}
 
+const domainRegex = /^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$/g
+
 export const RelayManagerScreen: FC<RelayManagerScreenProps> = observer(
   function RelayManagerScreen() {
     const bottomSheetModalRef = useRef<BottomSheetModal>(null)
@@ -93,8 +95,11 @@ export const RelayManagerScreen: FC<RelayManagerScreenProps> = observer(
 
     const addCustomRelay = () => {
       try {
-        const relay = new URL(url.trim())
-        if (relay.protocol === "wss:" || relay.protocol === "ws:") {
+        const relay = new URL(url.replace(/\s/g, ""))
+        if (
+          (domainRegex.test(relay.origin) && relay.protocol === "wss:") ||
+          relay.protocol === "ws:"
+        ) {
           if (!getRelays.includes(relay.origin)) {
             addRelay(relay.origin)
             setURL("")

--- a/app/utils/profile.tsx
+++ b/app/utils/profile.tsx
@@ -1,0 +1,102 @@
+import { ArcadeIdentity, NostrPool } from "app/arclib/src"
+import { ProfileManager, Profile } from "app/arclib/src/profile"
+import { registerForPushNotifications } from "./notification"
+import { Contact } from "app/arclib/src/contacts"
+
+export type PrivateSettings = {
+  privchat_push_enabled: boolean
+  channel_push_enabled: boolean
+  buyoffer_push_enabled: boolean
+  selloffer_push_enabled: boolean
+}
+
+// good to have a few non-arcade backups
+const ARCADE_RELAYS = [
+  "wss://relay.arcade.city",
+  "wss://arc1.arcadelabs.co",
+  "wss://relay.nostr.band/all",
+  "wss://relay.damus.io",
+  "wss://nos.lol",
+]
+
+const ARCADE_PUBKEY = "c4899d1312a7ccf42cc4bfd0559826d20f7564293de4588cb8b089a574d71757"
+
+export async function getProfile(ident: ArcadeIdentity, pubkey: string) {
+  const tmpPool = new NostrPool(ident)
+  await tmpPool.setRelays(ARCADE_RELAYS)
+
+  const contacts: Array<Contact> = []
+  let profile: Profile = {}
+
+  const list = await tmpPool.list([{ kinds: [0, 3], authors: [pubkey] }], true)
+  const metadata = list.filter((el) => el.kind === 0)?.slice(-1)[0]
+  const follows = list.filter((el) => el.kind === 3)?.slice(-1)[0]
+
+  if (metadata) {
+    profile = JSON.parse(metadata.content)
+  }
+
+  if (follows) {
+    follows.tags.forEach((item) => {
+      contacts.push({ pubkey: item[1], secret: false, legacy: true })
+    })
+  }
+
+  // close tmp pool
+  tmpPool.close()
+
+  return { profile, contacts }
+}
+
+export async function updateProfile(profmgr: ProfileManager, profile: Profile & PrivateSettings) {
+  // save public and private settings
+  await profmgr.save(profile, [
+    "privchat_push_enabled",
+    "channel_push_enabled",
+    "buyoffer_push_enabled",
+    "selloffer_push_enabled",
+  ])
+
+  // update arcade push notification settings
+  if (
+    profile.privchat_push_enabled ||
+    profile.channel_push_enabled ||
+    profile.buyoffer_push_enabled ||
+    profile.selloffer_push_enabled
+  ) {
+    const pool = profmgr.pool
+    const token = await registerForPushNotifications()
+
+    const pushSettings = {
+      pubkey: pool.ident.pubKey,
+      token,
+      privchat_push_enabled: profile.privchat_push_enabled,
+      channel_push_enabled: profile.channel_push_enabled,
+      buyoffer_push_enabled: profile.buyoffer_push_enabled,
+      selloffer_push_enabled: profile.selloffer_push_enabled,
+    }
+
+    const tmpPool = new NostrPool(pool.ident)
+    await tmpPool.setRelays(ARCADE_RELAYS)
+
+    // change to nip44 once that merges
+    const content = await pool.ident.nip04XEncrypt(
+      pool.ident.privKey,
+      ARCADE_PUBKEY,
+      JSON.stringify(pushSettings),
+    )
+
+    // use replceable event
+    await tmpPool.send({
+      kind: 30199,
+      content,
+      tags: [
+        ["d", "arcade-push"],
+        ["p", ARCADE_PUBKEY],
+      ],
+    })
+
+    // close tmp pool
+    tmpPool.close()
+  }
+}

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "react-native-svg": "13.4.0",
     "react-native-svg-transformer": "1.0.0",
     "react-native-url-polyfill": "^1.3.0",
+    "react-query": "^3.39.3",
     "react-string-replace": "^1.1.1",
     "reactotron-mst": "3.1.4",
     "reactotron-react-js": "^3.3.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1201,6 +1201,13 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+"@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2":
+  version "7.22.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.6.tgz#57d64b9ae3cff1d67eb067ae117dac087f5bd438"
+  integrity sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/template@^7.0.0", "@babel/template@^7.18.10", "@babel/template@^7.20.7", "@babel/template@^7.21.9", "@babel/template@^7.3.3":
   version "7.21.9"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.21.9.tgz#bf8dad2859130ae46088a99c1f265394877446fb"
@@ -3978,7 +3985,7 @@ better-sqlite3@^8.4.0:
     bindings "^1.5.0"
     prebuild-install "^7.1.0"
 
-big-integer@1.6.x:
+big-integer@1.6.x, big-integer@^1.6.16:
   version "1.6.51"
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
   integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
@@ -4128,6 +4135,20 @@ braces@^3.0.2, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^3.4.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.7.0.tgz#2dfa5c7b4289547ac3f6705f9c00af8723889937"
+  integrity sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.1.0"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    oblivious-set "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 brorand@^1.0.1:
   version "1.1.0"
@@ -5295,7 +5316,7 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-detect-node@^2.0.4:
+detect-node@^2.0.4, detect-node@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
@@ -8352,6 +8373,11 @@ join-component@^1.1.0:
   resolved "https://registry.yarnpkg.com/join-component/-/join-component-1.1.0.tgz#b8417b750661a392bee2c2537c68b2a9d4977cd5"
   integrity sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ==
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -8811,6 +8837,14 @@ map-visit@^1.0.0:
   integrity sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==
   dependencies:
     object-visit "^1.0.0"
+
+match-sorter@^6.0.2:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.1.tgz#98cc37fda756093424ddf3cbc62bfe9c75b92bda"
+  integrity sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
 
 md5-file@^3.2.3:
   version "3.2.3"
@@ -9467,6 +9501,11 @@ micromatch@^4.0.2, micromatch@^4.0.4:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
+
 mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
@@ -9726,6 +9765,13 @@ mz@^2.7.0:
     any-promise "^1.0.0"
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==
+  dependencies:
+    big-integer "^1.6.16"
 
 nanoid@^3.1.23, nanoid@^3.3.1, nanoid@^3.3.6:
   version "3.3.6"
@@ -10059,6 +10105,11 @@ object.values@^1.1.5:
     call-bind "^1.0.2"
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
+
+oblivious-set@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
+  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
@@ -11256,6 +11307,15 @@ react-native@0.71.8:
     whatwg-fetch "^3.0.0"
     ws "^6.2.2"
 
+react-query@^3.39.3:
+  version "3.39.3"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.39.3.tgz#4cea7127c6c26bdea2de5fb63e51044330b03f35"
+  integrity sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
+
 react-reconciler@^0.27.0:
   version "0.27.0"
   resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.27.0.tgz#360124fdf2d76447c7491ee5f0e04503ed9acf5b"
@@ -11481,6 +11541,11 @@ relateurl@^0.2.7:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==
+
 remove-trailing-slash@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/remove-trailing-slash/-/remove-trailing-slash-0.1.1.tgz#be2285a59f39c74d1bce4f825950061915e3780d"
@@ -11629,17 +11694,17 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
+rimraf@3.0.2, rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -13101,6 +13166,14 @@ universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
**Changes**

- Update metadata field in `UserStore`, store `parsed` user's profile (kind 0)
- Update login process, prefetch profile and contacts then store in MST
- Before, UI will fetch current user's profile every time needed. After, UI only fetch one time then store in MST, if user update their profile, modify in MST first then publish to relay, user will see profile updated immediately
- Move `updateProfile` function from `NotificationSettingsScreen` to `app/utils/profile.tsx`
- Add `getProfile` function which use to get user's profile and contacts
- Update contacts screen, preferred use saved metadata for user's profile, skip unnecessary relay request. Add button for refresh contacts
- **Experiment**: use react-query for handle external async (outside MST), such as: fetch channel user's profile

**Other fixes**
- Fix #268 
- Fix #264
- Fix #261 
- Fix #260 
- Fix #255 
- Fix #265
- Fix #263 
- Fix #277 
- Fix #278 
- Fix #279 
- Fix #280 
- Fix #281 
- Fix #289
- Fix #294
- Fix #292
- Fix #290
- Fix #293
- Fix #288
- Fix #286