### PR TITLE
New message form and other fixes

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -22,7 +22,7 @@ import * as storage from "./utils/storage"
 import { customFontsToLoad } from "./theme"
 import { setupReactotron } from "./services/reactotron"
 import Config from "./config"
-import { RelayProvider } from "./components/RelayProvider"
+import { RelayProvider } from "app/components"
 import { GestureHandlerRootView } from "react-native-gesture-handler"
 import { QueryClient, QueryClientProvider } from "react-query"
 

--- a/app/components/ChannelMessageForm.tsx
+++ b/app/components/ChannelMessageForm.tsx
@@ -76,7 +76,6 @@ export function ChannelMessageForm({
   }
 
   const createEvent = async (data) => {
-    // no popup here please
     if (!attached && data.content.length === 0) {
       // user does not need feedback, they were probably just trying to close the keyboard
       return
@@ -99,10 +98,9 @@ export function ChannelMessageForm({
       formikRef.current?.resetForm()
       setAttached(null)
       setLoading(false)
-      // log, todo: remove
-      console.log("published event to channel:", message.id)
     } else {
-      alert("Failed to publish")
+      // todo: put failed publish event to queue for resend
+      console.log("Failed to publish")
     }
   }
 
@@ -158,15 +156,25 @@ export function ChannelMessageForm({
                 style={$imageButton}
               />
             )}
-            RightAccessory={() => (
-              <Button
-                onPress={() => submitForm()}
-                LeftAccessory={() => (
-                  <ArrowUpIcon width={20} height={20} style={{ color: colors.palette.cyan100 }} />
-                )}
-                style={$sendButton}
-              />
-            )}
+            RightAccessory={() => {
+              if (attached || (values.content.length > 0 && /\S/.test(values.content))) {
+                return (
+                  <Button
+                    onPress={() => submitForm()}
+                    LeftAccessory={() => (
+                      <ArrowUpIcon
+                        width={20}
+                        height={20}
+                        style={{ color: colors.palette.cyan100 }}
+                      />
+                    )}
+                    style={$sendButton}
+                  />
+                )
+              } else {
+                return <View style={$blankButton} />
+              }
+            }}
           />
         </>
       )}
@@ -212,6 +220,11 @@ const $sendButton: ViewStyle = {
   borderWidth: 0,
   flexShrink: 0,
   marginRight: spacing.small,
+}
+
+const $blankButton: ViewStyle = {
+  width: 5,
+  height: 40,
 }
 
 const $imageButton: ViewStyle = {

--- a/app/components/ContactItem.tsx
+++ b/app/components/ContactItem.tsx
@@ -29,7 +29,7 @@ export function ContactItem({ pubkey, fallback }: { pubkey: string; fallback?: s
       />
       <View>
         <Text
-          text={profile?.display_name || profile?.username || "Loading..."}
+          text={profile?.display_name || profile?.username || profile?.name || "Loading..."}
           preset="bold"
           numberOfLines={1}
           style={$itemName}

--- a/app/components/DirectMessageForm.tsx
+++ b/app/components/DirectMessageForm.tsx
@@ -142,13 +142,19 @@ export function DirectMessageForm({
             />
           </View>
         )}
-        RightAccessory={() => (
-          <Button
-            onPress={() => submit()}
-            LeftAccessory={() => <SendIcon style={{ color: colors.text }} />}
-            style={$sendButton}
-          />
-        )}
+        RightAccessory={() => {
+          if (attached || (value.length > 0 && /\S/.test(value))) {
+            return (
+              <Button
+                onPress={() => submit()}
+                LeftAccessory={() => <SendIcon style={{ color: colors.text }} />}
+                style={$sendButton}
+              />
+            )
+          } else {
+            return <View style={$blankButton} />
+          }
+        }}
       />
     </>
   )
@@ -192,6 +198,11 @@ const $sendButton: ViewStyle = {
   borderWidth: 0,
   flexShrink: 0,
   marginRight: spacing.small,
+}
+
+const $blankButton: ViewStyle = {
+  width: 5,
+  height: 40,
 }
 
 const $imageButton: ViewStyle = {

--- a/app/components/RelayProvider.tsx
+++ b/app/components/RelayProvider.tsx
@@ -2,8 +2,8 @@ import React, { createContext, useEffect, useMemo, useState } from "react"
 import { useStores } from "app/models"
 import { connectDb, ArcadeIdentity, NostrPool, ArcadeDb } from "app/arclib/src"
 import { observer } from "mobx-react-lite"
-export const RelayContext = createContext({})
 
+export const RelayContext = createContext({})
 const db: ArcadeDb = connectDb()
 
 export const RelayProvider = observer(function RelayProvider({

--- a/app/components/RelayProvider.tsx
+++ b/app/components/RelayProvider.tsx
@@ -14,34 +14,28 @@ export const RelayProvider = observer(function RelayProvider({
   if (!db) throw new Error("cannot initialized db")
 
   const {
-    userStore: { getRelays, privkey, getMetadata, isNewUser, clearNewUser },
+    userStore: { getRelays, privkey },
   } = useStores()
 
   const ident = useMemo(() => (privkey ? new ArcadeIdentity(privkey, "", "") : null), [privkey])
-  const [pool, _setPool] = useState<NostrPool>(() => new NostrPool(ident, db, {skipVerification: true}))
+  const [pool, _setPool] = useState<NostrPool>(
+    () => new NostrPool(ident, db, { skipVerification: true }),
+  )
 
   useEffect(() => {
     pool.ident = ident
+
     async function initRelays() {
       await pool.setRelays(getRelays)
       console.log("connected to relays: ", getRelays)
-      if (isNewUser) {
-        console.log("creating user...")
-        const res = await pool.send({
-          content: JSON.stringify(getMetadata),
-          tags: [],
-          kind: 0,
-        })
-        console.log("created:", res)
-        clearNewUser()
-      }
     }
+
     initRelays().catch(console.error)
 
     return () => {
       pool.close()
     }
-  }, [ident, getRelays, isNewUser])
+  }, [ident, getRelays])
 
   return <RelayContext.Provider value={pool}>{children}</RelayContext.Provider>
 })

--- a/app/models/UserStore.ts
+++ b/app/models/UserStore.ts
@@ -235,34 +235,20 @@ export const UserStoreModel = types
         const privMessages = yield self.fetchPrivMessages(pool, contacts)
 
         // update mobx state, user will redirect to home screen immediately
-        try {
-          /*
-          const tmp = yield mgr.listChannels()
-          tmp.forEach((el: ChannelInfo) => {
-            self.channels.push(ChannelModel.create(el))
-          })
-          const joinedChannels = tmp.map((item: ChannelInfo) => item.id)
-          */
-          applySnapshot(self, {
-            pubkey,
-            privkey,
-            isLoggedIn: true,
-            metadata: profile,
-            contacts,
-            channels: DEFAULT_CHANNELS,
-            privMessages,
-          })
-        } catch {
-          applySnapshot(self, {
-            pubkey,
-            privkey,
-            isLoggedIn: true,
-            metadata: profile,
-            contacts,
-            channels: DEFAULT_CHANNELS,
-            privMessages,
-          })
-        }
+        const tmp = yield mgr.listJoined()
+        tmp.forEach((id: string) => {
+          ChannelModel.create({ id, privkey: "" })
+        })
+        const joinedChannels = DEFAULT_CHANNELS.concat(tmp)
+        applySnapshot(self, {
+          pubkey,
+          privkey,
+          isLoggedIn: true,
+          metadata: profile,
+          contacts,
+          channels: joinedChannels,
+          privMessages,
+        })
       } catch (e: any) {
         console.log(e)
         alert("Invalid key. Did you copy it correctly?")

--- a/app/models/UserStore.ts
+++ b/app/models/UserStore.ts
@@ -104,6 +104,9 @@ export const UserStoreModel = types
     get getMetadata() {
       return self.metadata
     },
+    get getPrivMesages() {
+      return [...new Map(self.privMessages.slice().map((item) => [item.pubkey, item])).values()]
+    },
   })) // eslint-disable-line @typescript-eslint/no-unused-vars
   .actions((self) => ({
     fetchPrivMessages: flow(function* (pool: NostrPool, contacts?: Array<Contact>) {

--- a/app/models/UserStore.ts
+++ b/app/models/UserStore.ts
@@ -1,4 +1,12 @@
-import { Instance, SnapshotIn, SnapshotOut, applySnapshot, flow, types } from "mobx-state-tree"
+import {
+  Instance,
+  SnapshotIn,
+  SnapshotOut,
+  applySnapshot,
+  flow,
+  cast,
+  types,
+} from "mobx-state-tree"
 import { withSetPropAction } from "./helpers/withSetPropAction"
 import {
   ArcadeIdentity,
@@ -304,6 +312,9 @@ export const UserStoreModel = types
         ...ev,
         lastMessageAt: ev.created_at,
       })
+    },
+    updatePrivMessages(data) {
+      self.privMessages = cast(data)
     },
     updateChannels: flow(function* (mgr: ChannelManager) {
       const list = yield mgr.listChannels(true)

--- a/app/models/UserStore.ts
+++ b/app/models/UserStore.ts
@@ -239,7 +239,7 @@ export const UserStoreModel = types
         tmp.forEach((id: string) => {
           ChannelModel.create({ id, privkey: "" })
         })
-        const joinedChannels = DEFAULT_CHANNELS.concat(tmp)
+        const joinedChannels = tmp.length > 0 ? tmp : DEFAULT_CHANNELS
         applySnapshot(self, {
           pubkey,
           privkey,

--- a/app/models/UserStore.ts
+++ b/app/models/UserStore.ts
@@ -1,12 +1,4 @@
-import {
-  Instance,
-  SnapshotIn,
-  SnapshotOut,
-  applySnapshot,
-  cast,
-  flow,
-  types,
-} from "mobx-state-tree"
+import { Instance, SnapshotIn, SnapshotOut, applySnapshot, flow, types } from "mobx-state-tree"
 import { withSetPropAction } from "./helpers/withSetPropAction"
 import {
   ArcadeIdentity,
@@ -89,7 +81,6 @@ export const UserStoreModel = types
       }),
     ),
     isLoggedIn: false,
-    isNewUser: false,
     channels: types.array(types.reference(ChannelModel)),
     contacts: types.optional(types.array(ContactModel), []),
     privMessages: types.optional(types.array(MessageModel), []),
@@ -115,6 +106,53 @@ export const UserStoreModel = types
     },
   })) // eslint-disable-line @typescript-eslint/no-unused-vars
   .actions((self) => ({
+    fetchPrivMessages: flow(function* (pool: NostrPool, contacts?: Array<Contact>) {
+      const priv = new PrivateMessageManager(pool)
+      let keys: string[]
+      if (contacts) {
+        keys = contacts.map((c) => c.pubkey)
+      } else {
+        keys = self.contacts.map((c) => c.pubkey)
+      }
+      // this doesn't work... you get mobx errors
+      // but we should be able to update the state!
+
+      /*
+      const modifyProp = async (ev: BlindedEvent) => {
+        if (self.privMessages.every(msg=>{
+            if (msg.pubkey === ev.pubkey) {
+              console.log("modding", ev.pubkey)
+              msg.setProp("content", ev.content)
+              msg.setProp("blinded", ev.blinded)
+              msg.setProp("lastMessageAt", ev.created_at)
+              return false
+            }
+           return true
+        })) {
+          // append!
+        }
+      }
+      */
+
+      // this updates the home screen prop when new messages arrive
+      // by passing in all our contact keys, we can decrypt new blinded messages
+      const list = yield priv.list({ limit: 500 }, false, keys)
+      const map = new Map<string, NostrEvent>()
+      list.forEach((ev) => {
+        const was = map.get(ev.pubkey)
+        if (!was || ev.created_at > was.created_at) {
+          map.set(ev.pubkey, ev)
+        }
+      })
+      type ExtendedItem = NostrEvent & { lastMessageAt?: number; name?: string }
+      const uniqueList: ExtendedItem[] = [...map.values()]
+      for (const item of uniqueList) {
+        item.lastMessageAt = item.created_at
+      }
+      return uniqueList
+    }),
+  }))
+  .actions((self) => ({
     joinChannel(mgr: ChannelManager, info: ChannelInfo) {
       const index = self.channels.findIndex((el: { id: string }) => el.id === info.id)
       if (index === -1) self.channels.push(ChannelModel.create(info))
@@ -134,24 +172,40 @@ export const UserStoreModel = types
           self.setProp("privkey", sec)
           self.setProp("pubkey", pubkey)
           self.setProp("isLoggedIn", true)
-          self.setProp("isNewUser", false)
           self.setProp("metadata", meta)
         })
       }
     },
-    signup: flow(function* (picture: string, username: string, displayName: string, about: string) {
+    signup: flow(function* (
+      pool: NostrPool,
+      picture: string,
+      username: string,
+      displayName: string,
+      about: string,
+    ) {
       const privkey = generatePrivateKey()
       const pubkey = getPublicKey(privkey)
-      const id = new ArcadeIdentity(privkey)
 
+      // update pool with ident
+      const id = new ArcadeIdentity(privkey)
+      pool.ident = id
+
+      // register nip-05
       const nip05 = yield registerNip05(id, username)
+
+      // publish user to relay
       const meta = { picture, display_name: displayName, username, about, nip05 }
+      const res = yield pool.send({
+        content: JSON.stringify(meta),
+        tags: [],
+        kind: 0,
+      })
+      console.log("publish user", res)
 
       applySnapshot(self, {
         pubkey,
         privkey,
         isLoggedIn: true,
-        isNewUser: true,
         metadata: meta,
         channels: DEFAULT_CHANNELS,
       })
@@ -159,7 +213,7 @@ export const UserStoreModel = types
       yield secureSet("privkey", privkey)
       yield storage.save("meta", meta)
     }),
-    loginWithNsec: flow(function* (mgr: ChannelManager, nsec: string) {
+    loginWithNsec: flow(function* (pool: NostrPool, mgr: ChannelManager, nsec: string) {
       if (!nsec.startsWith("nsec1") || nsec.length < 60) {
         return
       }
@@ -167,38 +221,45 @@ export const UserStoreModel = types
         const { data } = nip19.decode(nsec)
         const privkey = data as string
         const pubkey = getPublicKey(privkey)
-        const ident = new ArcadeIdentity(privkey)
-        mgr.pool.ident = ident
-        const { profile, contacts } = yield getProfile(ident, pubkey)
 
+        const ident = new ArcadeIdentity(privkey)
+        pool.ident = ident
+
+        const { profile, contacts } = yield getProfile(ident, pubkey)
+        // update secure storage
+        yield secureSet("privkey", privkey)
+        // fetch priv messages
+        const privMessages = yield self.fetchPrivMessages(pool, contacts)
+
+        // update mobx state, user will redirect to home screen immediately
         try {
-          throw Error("no way to load mobx references, skipping channel load")
           /*
           const tmp = yield mgr.listChannels()
-          const channels = []
-          applySnapshot(self, {
-            pubkey,
-            privkey,
-            isLoggedIn: true,
-            metadata: profile,
-            contacts
-          })
           tmp.forEach((el: ChannelInfo) => {
             self.channels.push(ChannelModel.create(el))
           })
+          const joinedChannels = tmp.map((item: ChannelInfo) => item.id)
           */
-        } catch {
-          const channels = DEFAULT_CHANNELS
           applySnapshot(self, {
             pubkey,
             privkey,
             isLoggedIn: true,
             metadata: profile,
             contacts,
-            channels,
+            channels: DEFAULT_CHANNELS,
+            privMessages,
+          })
+        } catch {
+          applySnapshot(self, {
+            pubkey,
+            privkey,
+            isLoggedIn: true,
+            metadata: profile,
+            contacts,
+            channels: DEFAULT_CHANNELS,
+            privMessages,
           })
         }
-        yield secureSet("privkey", privkey)
       } catch (e: any) {
         console.log(e)
         alert("Invalid key. Did you copy it correctly?")
@@ -210,7 +271,6 @@ export const UserStoreModel = types
         pubkey: "",
         privkey: "",
         isLoggedIn: false,
-        isNewUser: false,
         channels: [],
         contacts: [],
       })
@@ -267,46 +327,6 @@ export const UserStoreModel = types
         }
       })
     }),
-    fetchPrivMessages: flow(function* (pool: NostrPool) {
-      const priv = new PrivateMessageManager(pool)
-      const keys = self.contacts.map((c) => c.pubkey)
-      // this doesn't work... you get mobx errors
-      // but we should be able to update the state!
-
-      /*
-      const modifyProp = async (ev: BlindedEvent) => {
-        if (self.privMessages.every(msg=>{
-            if (msg.pubkey === ev.pubkey) {
-              console.log("modding", ev.pubkey)
-              msg.setProp("content", ev.content)
-              msg.setProp("blinded", ev.blinded)
-              msg.setProp("lastMessageAt", ev.created_at)
-              return false
-            }
-           return true
-        })) {
-          // append!
-        }
-      }
-      */
-
-      // this updates the home screen prop when new messages arrive
-      // by passing in all our contact keys, we can decrypt new blinded messages
-      const list = yield priv.list({ limit: 500 }, false, keys)
-      const map = new Map<string, NostrEvent>()
-      list.forEach((ev) => {
-        const was = map.get(ev.pubkey)
-        if (!was || ev.created_at > was.created_at) {
-          map.set(ev.pubkey, ev)
-        }
-      })
-      type ExtendedItem = NostrEvent & { lastMessageAt?: number; name?: string }
-      const uniqueList: ExtendedItem[] = [...map.values()]
-      for (const item of uniqueList) {
-        item.lastMessageAt = item.created_at
-      }
-      self.privMessages = cast(uniqueList)
-    }),
     fetchMetadata: flow(function* () {
       const ident = new ArcadeIdentity(self.privkey)
       const { profile } = yield getProfile(ident, self.pubkey)
@@ -318,9 +338,6 @@ export const UserStoreModel = types
       }
       self.setProp("metadata", data)
     }),
-    clearNewUser() {
-      self.setProp("isNewUser", false)
-    },
   })) // eslint-disable-line @typescript-eslint/no-unused-vars
 
 export interface UserStore extends Instance<typeof UserStoreModel> {}

--- a/app/screens/CreateAccountScreen.tsx
+++ b/app/screens/CreateAccountScreen.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useLayoutEffect, useRef, useState } from "react"
+import React, { FC, useContext, useLayoutEffect, useRef, useState } from "react"
 import { observer } from "mobx-react-lite"
 import {
   ActivityIndicator,
@@ -11,13 +11,14 @@ import {
 } from "react-native"
 import { NativeStackScreenProps } from "@react-navigation/native-stack"
 import { AppStackScreenProps } from "app/navigators"
-import { Header, Screen, TextField, Button, AutoImage, Text } from "app/components"
+import { Header, Screen, TextField, Button, AutoImage, Text, RelayContext } from "app/components"
 import { colors, spacing } from "app/theme"
 import { useNavigation } from "@react-navigation/native"
 import { useStores } from "app/models"
 import { Formik } from "formik"
 import { launchImageLibrary } from "react-native-image-picker"
 import { ImagePlusIcon } from "lucide-react-native"
+import { NostrPool } from "app/arclib/src"
 
 interface CreateAccountScreenProps
   extends NativeStackScreenProps<AppStackScreenProps<"CreateAccount">> {}
@@ -30,6 +31,7 @@ interface ISignup {
 
 export const CreateAccountScreen: FC<CreateAccountScreenProps> = observer(
   function CreateAccountScreen() {
+    const pool = useContext(RelayContext) as NostrPool
     const formikRef = useRef(null)
 
     const [loading, setLoading] = useState(false)
@@ -89,10 +91,12 @@ export const CreateAccountScreen: FC<CreateAccountScreenProps> = observer(
         alert("Username is invalid, please check again")
       } else {
         setLoading(true)
-        await userStore.signup(picture, data.username, data.displayName, data.about).catch((e) => {
-          alert(e)
-          setLoading(false)
-        })
+        await userStore
+          .signup(pool, picture, data.username, data.displayName, data.about)
+          .catch((e) => {
+            alert(e)
+            setLoading(false)
+          })
       }
     }
 

--- a/app/screens/HomeMessagesScreen.tsx
+++ b/app/screens/HomeMessagesScreen.tsx
@@ -1,6 +1,6 @@
-import React, { FC, useCallback, useContext } from "react"
+import React, { FC, useCallback, useContext, useEffect, useRef, useState } from "react"
 import { observer } from "mobx-react-lite"
-import { View, StyleSheet } from "react-native"
+import { View, StyleSheet, RefreshControl } from "react-native"
 import { NativeStackScreenProps } from "@react-navigation/native-stack"
 import { AppStackScreenProps } from "app/navigators"
 import { ScreenWithSidebar, ChannelItem, Text, RelayContext } from "app/components"
@@ -11,7 +11,6 @@ import { DirectMessageItem } from "app/components/DirectMessageItem"
 import { StatusBar } from "expo-status-bar"
 import { spacing } from "app/theme"
 import Animated, { FadeInDown } from "react-native-reanimated"
-import { useFocusEffect } from "@react-navigation/native"
 
 interface HomeMessagesScreenProps
   extends NativeStackScreenProps<AppStackScreenProps<"HomeMessages">> {}
@@ -26,44 +25,61 @@ const colors = {
 
 export const HomeMessagesScreen: FC<HomeMessagesScreenProps> = observer(
   function HomeMessagesScreen() {
+    const now = useRef(Math.floor(Date.now() / 1000))
     const pool = useContext(RelayContext) as NostrPool
     const channelManager = new ChannelManager(pool) as ChannelManager
     const pmgr = new PrivateMessageManager(pool) as PrivateMessageManager
 
+    const [isRefresh, setIsRefresh] = useState(false)
+
     const {
-      userStore: { pubkey, getChannels, getPrivMesages, addPrivMessage },
+      userStore: {
+        pubkey,
+        getChannels,
+        getPrivMesages,
+        addPrivMessage,
+        fetchPrivMessages,
+        updatePrivMessages,
+      },
     } = useStores()
-
-    useFocusEffect(
-      useCallback(() => {
-        function handleNewMessage(event: BlindedEvent) {
-          console.log("new message", event)
-          addPrivMessage(event)
-        }
-
-        async function subscribe() {
-          console.log("subscribe")
-          return await pmgr.sub(handleNewMessage, {
-            kinds: [4],
-            "#p": [pubkey],
-            since: Math.floor(Date.now() / 1000),
-          })
-        }
-
-        // subscribe for new messages
-        subscribe().catch(console.error)
-
-        return () => {
-          console.log("unsubscribe")
-          pool.unsub(handleNewMessage)
-        }
-      }, []),
-    )
 
     const data = [...getChannels, ...getPrivMesages].sort(
       (a: { lastMessageAt: number }, b: { lastMessageAt: number }) =>
         b.lastMessageAt - a.lastMessageAt,
     )
+
+    const refresh = async () => {
+      setIsRefresh(true)
+      const messages = await fetchPrivMessages(pool)
+      if (messages) {
+        updatePrivMessages(messages)
+      }
+      setIsRefresh(false)
+    }
+
+    useEffect(() => {
+      function handleNewMessage(event: BlindedEvent) {
+        console.log("new message", event)
+        addPrivMessage(event)
+      }
+
+      async function subscribe() {
+        return pmgr.sub(handleNewMessage, {
+          kinds: [4],
+          "#p": [pubkey],
+          since: now.current,
+        })
+      }
+
+      if (pool.ident) {
+        // subscribe for new messages
+        subscribe().catch(console.error)
+      }
+
+      return () => {
+        pool.unsub(handleNewMessage)
+      }
+    }, [])
 
     const renderItem = useCallback(({ item, index }) => {
       return (
@@ -93,6 +109,14 @@ export const HomeMessagesScreen: FC<HomeMessagesScreenProps> = observer(
           contentContainerStyle={styles.list}
           showsVerticalScrollIndicator={false}
           showsHorizontalScrollIndicator={false}
+          refreshControl={
+            <RefreshControl
+              colors={[colors.logo, colors.logoActive]}
+              tintColor={colors.logoActive}
+              refreshing={isRefresh}
+              onRefresh={refresh}
+            />
+          }
         />
       </ScreenWithSidebar>
     )

--- a/app/screens/LoginScreen.tsx
+++ b/app/screens/LoginScreen.tsx
@@ -1,15 +1,16 @@
-import React, { FC, useLayoutEffect, useState } from "react"
+import React, { FC, useContext, useLayoutEffect, useState } from "react"
 import { observer } from "mobx-react-lite"
 import { ActivityIndicator, Pressable, TextStyle, View, ViewStyle } from "react-native"
 import { NativeStackScreenProps } from "@react-navigation/native-stack"
 import { AppStackScreenProps } from "app/navigators"
-import { Button, Header, Screen, Text, TextField } from "app/components"
+import { Button, Header, RelayContext, Screen, Text, TextField } from "app/components"
 import { useNavigation } from "@react-navigation/native"
 import { useStores } from "app/models"
 import { colors, spacing } from "app/theme"
 import { EyeIcon, EyeOffIcon } from "lucide-react-native"
 import { nip19 } from "nostr-tools"
 import { useChannelManager } from "app/utils/useUserContacts"
+import { NostrPool } from "app/arclib/src"
 
 interface LoginScreenProps extends NativeStackScreenProps<AppStackScreenProps<"Login">> {}
 
@@ -21,6 +22,7 @@ export const LoginScreen: FC<LoginScreenProps> = observer(function LoginScreen()
   // Pull in one of our MST stores
   const { userStore } = useStores()
 
+  const pool = useContext(RelayContext) as NostrPool
   const mgr = useChannelManager()
 
   // Pull in navigation via hook
@@ -38,7 +40,7 @@ export const LoginScreen: FC<LoginScreenProps> = observer(function LoginScreen()
         accessKey = nip19.nsecEncode(accessKey)
       }
 
-      userStore.loginWithNsec(mgr, accessKey)
+      userStore.loginWithNsec(pool, mgr, accessKey)
     }
   }
 


### PR DESCRIPTION
**Changes**

- Remove `publish user to relay` logic from relay provider, move it to MST `signup` action. Now, relay provider only handle connection to relay no more other logic
- Update UX for message form
- Add fetch priv messages to login step, `user login -> fetch profile/contacts/priv messages -> move to home screen`
- Add subscribe function for new message to home screen